### PR TITLE
Route managed mutations through quarantine

### DIFF
--- a/.just-for-agents/agent.just
+++ b/.just-for-agents/agent.just
@@ -47,9 +47,9 @@ escalate prompt:
     COPILOT_BIN="$(command -v copilot)"
     PROMPT_TEXT="You are a Senior Creator Agent. A junior agent needs a skill upgrade: '{{prompt}}'.
     1. Examine the current Justfile.
-    2. Use 'add-tool' to implement the missing capability.
-    3. Ensure the new tool is robust and follows the project's RADICALLY SIMPLE principle.
-    4. Verify the new tool appears in 'just schema'."
+    2. Stage the change with 'managed-new', 'managed-edit', or 'managed-delete' so it lands in the quarantined managed queue instead of the live Just surface.
+    3. Ensure the candidate recipe is robust and follows the project's RADICALLY SIMPLE principle.
+    4. Verify the request is visible in 'just managed-queue' and that unapproved recipes do not leak into 'just schema'."
     RUNNER=$(mktemp "${TMPDIR%/}/just-for-agents-escalate.XXXXXX")
     trap 'rm -f "$RUNNER"' EXIT
     WORKDIR_Q=$(printf '%q' "$PWD")

--- a/.just-for-agents/bridge.py
+++ b/.just-for-agents/bridge.py
@@ -16,7 +16,7 @@ MANIFEST = {
         "Use '@recipe:' or prefix individual lines with '@' to suppress command echoing, but do not combine both in the same recipe.",
         "Use curly-brace syntax for argument substitution.",
         "Documentation lives in [doc('@desc ...')] attributes.",
-        "Agents can extend the API using the 'add-tool' recipe.",
+        "Agents stage managed recipe changes with 'managed-new', 'managed-edit', and 'managed-delete'; reserve 'add-tool' for protected protocol maintenance.",
         "Linux users: review https://github.com/terror/just-lsp before using install-lsp.",
     ],
 }

--- a/.just-for-agents/managed.just
+++ b/.just-for-agents/managed.just
@@ -11,6 +11,18 @@
     python3 -m just_for_agents inspect "{{request_id}}"
 
 [no-cd]
+@new recipe_name command desc='' params='' author='' review_notes='':
+    python3 -m just_for_agents new "{{recipe_name}}" --command "{{command}}" --desc "{{desc}}" --params "{{params}}" --author "{{author}}" --review-notes "{{review_notes}}"
+
+[no-cd]
+@edit recipe_name author='' review_notes='':
+    python3 -m just_for_agents edit "{{recipe_name}}" --author "{{author}}" --review-notes "{{review_notes}}"
+
+[no-cd]
+@delete recipe_name author='' review_notes='':
+    python3 -m just_for_agents delete "{{recipe_name}}" --author "{{author}}" --review-notes "{{review_notes}}"
+
+[no-cd]
 @render-include:
     python3 -m just_for_agents render-include
 

--- a/.just-for-agents/protocol.just
+++ b/.just-for-agents/protocol.just
@@ -6,7 +6,7 @@
 @bootstrap:
     echo "AGENT INSTRUCTIONS:"
     echo "1. This project uses 'just-for-agents'. Run 'just' to discover the API."
-    echo "2. Use 'add-tool' to persist new capabilities."
+    echo "2. Use 'managed-new', 'managed-edit', and 'managed-delete' for governed recipe changes; reserve 'add-tool' for protected protocol maintenance."
     echo "3. Always prefix agent-facing documentation with '@tag' inside [doc('')]."
     echo "4. Agents supporting LSPs should run 'just install-lsp' and use 'just-lsp' for Justfile navigation and refactors."
     echo "5. Update CHANGELOG.md before stopping if you changed the repository."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Added a design spec for a governed managed-recipe overlay with quarantine, human approval, git-backed audit history, and a hybrid terminal-plus-browser operator surface.
 - Added the managed-overlay foundation: a new `just_for_agents/` Python package (`managed_paths`, `request_store`, and a `python -m just_for_agents` CLI), a `.just-for-agents/managed.just` partition, and root-level `managed-bootstrap`, `managed-queue`, and `managed-inspect` recipes so quarantined requests land in a single auditable layout discoverable via `just schema` (JFA-81).
 - Added the approval core: `just_for_agents/projection.py` rebuilds `approved/includes/managed.just` deterministically, `just_for_agents/history.py` initializes a dedicated managed git repo and records one commit plus one decision-ledger entry per approval, and the new `managed-render-include` and `managed-approve` recipes plus an optional root-Justfile `import?` make approved managed recipes the only live include surface (JFA-82).
+- Added quarantined mutation staging for managed recipes: `managed-new`, `managed-edit`, and `managed-delete` now create request artifacts through `just_for_agents/mutations.py`, `just escalate` stages candidate capability work into the queue instead of publishing directly, and README/testing coverage documents the managed review flow (JFA-83).
 
 ## [0.3.0] - 2026-04-30
 

--- a/Justfile
+++ b/Justfile
@@ -19,18 +19,18 @@ import? '.just-for-agents/managed/approved/includes/managed.just'
 @version:
     just --justfile ./.just-for-agents/protocol.just version
 
-[doc("@desc Add a new tool to the Justfile
+[doc("@desc Add a protected core tool directly to the root Justfile
 @param name The name of the new recipe
 @param command The shell command to execute
 @param desc a short description
 @param params Optional parameters (e.g. arg1 arg2=val)
-@usage Use this to expand the agent API surface.")]
+@usage Use this only for protected protocol maintenance; normal managed recipes should use managed-new.")]
 @add-tool name command desc='' params='':
     just --justfile ./.just-for-agents/protocol.just add-tool "{{name}}" "{{command}}" "{{desc}}" "{{params}}"
 
-[doc('@desc Remove a tool from the Justfile
+[doc('@desc Remove a protected core tool from the root Justfile
 @param name The name of the recipe to remove
-@usage Use this to clean up unused or deprecated tools.')]
+@usage Use this only for protected protocol maintenance; normal managed recipes should use managed-delete.')]
 @remove-tool name:
     just --justfile ./.just-for-agents/protocol.just remove-tool "{{name}}"
 
@@ -83,6 +83,36 @@ opencode-enable-exa-mcp:
 @returns json")]
 @managed-inspect request_id:
     just --justfile ./.just-for-agents/managed.just inspect "{{request_id}}"
+
+[doc("@desc Stage a new managed recipe in the quarantined review queue
+@param recipe_name The managed recipe name to create
+@param command The recipe body command(s)
+@param desc Optional @desc metadata for the candidate recipe
+@param params Optional recipe parameter list (e.g. target='' force='false')
+@param author Optional operator label recorded on the request
+@param review_notes Optional freeform notes stored on the request
+@usage just managed-new recipe_name='hello' command='echo hi'
+@returns json")]
+@managed-new recipe_name command desc='' params='' author='' review_notes='':
+    just --justfile ./.just-for-agents/managed.just new "{{recipe_name}}" "{{command}}" "{{desc}}" "{{params}}" "{{author}}" "{{review_notes}}"
+
+[doc("@desc Clone an approved managed recipe into a quarantined edit request
+@param recipe_name The approved managed recipe name
+@param author Optional operator label recorded on the request
+@param review_notes Optional freeform notes stored on the request
+@usage just managed-edit recipe_name='hello'
+@returns json")]
+@managed-edit recipe_name author='' review_notes='':
+    just --justfile ./.just-for-agents/managed.just edit "{{recipe_name}}" "{{author}}" "{{review_notes}}"
+
+[doc("@desc Stage a quarantined delete request for an approved managed recipe
+@param recipe_name The approved managed recipe name
+@param author Optional operator label recorded on the request
+@param review_notes Optional freeform notes stored on the request
+@usage just managed-delete recipe_name='hello'
+@returns json")]
+@managed-delete recipe_name author='' review_notes='':
+    just --justfile ./.just-for-agents/managed.just delete "{{recipe_name}}" "{{author}}" "{{review_notes}}"
 
 [doc("@desc Rebuild the approved managed-recipe include from approved/recipes/
 @usage Run after editing approved state by hand or to verify the projection.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ just research-reset
 
 If you use local Ollama aliases, keep the **consumer** and **research** roles separate. A chat-oriented Consumer model can power Pi, while `just research` can prefer a dedicated research-tuned model such as `just-research-qwen3.6:latest`.
 
+### **Managed Recipe Queue**
+
+Managed non-core recipe mutations now stage through the quarantined queue instead of publishing directly into the live Just surface.
+
+```bash
+just managed-new recipe_name='hello' command='echo hi' desc='Say hi'
+just managed-edit recipe_name='hello'
+just managed-delete recipe_name='hello'
+just managed-queue
+just managed-inspect req-20260501-001
+just managed-approve req-20260501-001 operator='you' rationale='reviewed'
+```
+
+Until a request is approved, it stays under `.just-for-agents/managed/quarantine/requests/` and does **not** appear in `just schema` or `just --list`. `just escalate` follows the same path, so escalated capability work lands in the review queue first.
+
 ### **Versioning**
 
 The canonical project version lives in the root `VERSION` file and follows semantic versioning.

--- a/docs/annexes/senior_agent.md
+++ b/docs/annexes/senior_agent.md
@@ -14,8 +14,8 @@ When invoked via `escalate`, the Senior Agent receives a prompt describing the m
 1. **Examine**: Read the current `Justfile` to understand existing patterns and constraints.
    - When the Just LSP is available, use it for Justfile navigation and symbol-aware edits instead of relying only on raw text search.
 2. **Design**: Create a robust shell script or command that fulfills the request.
-3. **Implement**: Use the `just add-tool` recipe to persist the change.
-4. **Verify**: Run `just schema` to ensure the new tool is discoverable.
+3. **Implement**: Use `just managed-new`, `just managed-edit`, or `just managed-delete` to stage the change in quarantine instead of publishing directly.
+4. **Verify**: Run `just managed-queue` and `just schema` to ensure the request is staged and unapproved tools stay undiscoverable.
 5. **Document**: Update `CHANGELOG.md` before stopping if the repo changed.
 
 ### Example: Skill Upgrade Prompt
@@ -44,11 +44,11 @@ Every new tool MUST include high-quality metadata using the `[doc('')]` attribut
 ## 🧪 Validation Workflow
 
 Senior Agents should follow this cycle when adding a tool:
-1. **Draft**: Formulate the `just add-tool` call.
+1. **Draft**: Formulate the `just managed-new` or `just managed-edit` call.
 2. **Execute**: Apply the change.
-3. **Audit**: Run `just schema` and verify the JSON output matches expectations.
+3. **Audit**: Run `just managed-queue` and `just schema`, verifying the request exists while the live schema stays unchanged until approval.
 4. **Document**: Record notable repo changes in `CHANGELOG.md`.
 5. **Test**: (Optional) Run the newly created tool to verify behavior.
 
 ## 🔄 Self-Correction
-If `add-tool` fails due to syntax errors (e.g., unescaped quotes in multi-line scripts), the Senior Agent is expected to use its high reasoning to diagnose the `Justfile` corruption and fix it manually or via `remove-tool`.
+If a managed mutation request fails due to syntax errors (for example, malformed multi-line recipe bodies), the Senior Agent is expected to diagnose the candidate recipe, restage it through the managed queue, and keep the live Just surface unchanged until approval.

--- a/just_for_agents/__init__.py
+++ b/just_for_agents/__init__.py
@@ -1,7 +1,8 @@
 """just-for-agents support package.
 
 Hosts helpers for the managed recipe governance overlay: filesystem layout
-(`managed_paths`) and quarantined change-request persistence (`request_store`).
+(`managed_paths`), quarantined change-request persistence (`request_store`),
+manual mutation staging (`mutations`), and approval/projection helpers.
 """
 
 from .history import (
@@ -12,19 +13,33 @@ from .history import (
     ensure_managed_repo,
 )
 from .managed_paths import ManagedPaths, ensure_managed_layout
+from .mutations import (
+    MutationError,
+    approved_recipe_path,
+    create_delete_request,
+    create_edit_request,
+    create_new_request,
+    render_candidate_recipe,
+)
 from .projection import render_include, write_include
 from .request_store import Request, RequestStore
 
 __all__ = [
     "ApprovalError",
     "ManagedPaths",
+    "MutationError",
     "Request",
     "RequestStore",
+    "approved_recipe_path",
     "append_decision",
     "approve_request",
     "commit_approval",
+    "create_delete_request",
+    "create_edit_request",
+    "create_new_request",
     "ensure_managed_layout",
     "ensure_managed_repo",
+    "render_candidate_recipe",
     "render_include",
     "write_include",
 ]

--- a/just_for_agents/__main__.py
+++ b/just_for_agents/__main__.py
@@ -5,6 +5,9 @@ Exposes the minimal surface needed by the root Justfile's `managed-*` recipes:
 * ``bootstrap`` — materialize the managed overlay layout, idempotent.
 * ``queue`` — list quarantined change requests (id, source, target recipes).
 * ``inspect <request_id>`` — print one request's full JSON.
+* ``new <name>`` — stage a manual-add request with a candidate recipe body.
+* ``edit <name>`` — clone one approved managed recipe into quarantine.
+* ``delete <name>`` — stage a tombstone request for one approved recipe.
 * ``render-include`` — rebuild ``approved/includes/managed.just`` from approved/recipes/.
 * ``approve <request_id>`` — approve a quarantined request, project, commit, ledger.
 """
@@ -18,6 +21,12 @@ from pathlib import Path
 
 from .history import ApprovalError, approve_request
 from .managed_paths import ensure_managed_layout
+from .mutations import (
+    MutationError,
+    create_delete_request,
+    create_edit_request,
+    create_new_request,
+)
 from .projection import write_include
 from .request_store import RequestStore
 
@@ -65,6 +74,73 @@ def cmd_inspect(args: argparse.Namespace) -> int:
     return 0
 
 
+def _request_payload(store: RequestStore, request_id: str, artifact_path: Path, key: str) -> dict:
+    request = store.get(request_id)
+    if request is None:
+        raise RuntimeError(f"newly created request vanished: {request_id}")
+    payload = request.to_dict()
+    payload["request_path"] = str(store.request_dir(request_id))
+    payload[key] = str(artifact_path)
+    return payload
+
+
+def cmd_new(args: argparse.Namespace) -> int:
+    paths = ensure_managed_layout(_repo_root())
+    store = RequestStore(paths)
+    try:
+        request, candidate = create_new_request(
+            paths,
+            store,
+            recipe_name=args.recipe_name,
+            command=args.command,
+            desc=args.desc,
+            params=args.params,
+            author_label=args.author,
+            review_notes=args.review_notes,
+        )
+    except MutationError as exc:
+        print(f"mutation failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(_request_payload(store, request.request_id, candidate, "candidate_path"), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_edit(args: argparse.Namespace) -> int:
+    paths = ensure_managed_layout(_repo_root())
+    store = RequestStore(paths)
+    try:
+        request, candidate = create_edit_request(
+            paths,
+            store,
+            recipe_name=args.recipe_name,
+            author_label=args.author,
+            review_notes=args.review_notes,
+        )
+    except MutationError as exc:
+        print(f"mutation failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(_request_payload(store, request.request_id, candidate, "candidate_path"), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    paths = ensure_managed_layout(_repo_root())
+    store = RequestStore(paths)
+    try:
+        request, tombstone = create_delete_request(
+            paths,
+            store,
+            recipe_name=args.recipe_name,
+            author_label=args.author,
+            review_notes=args.review_notes,
+        )
+    except MutationError as exc:
+        print(f"mutation failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(_request_payload(store, request.request_id, tombstone, "tombstone_path"), indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_render_include(_args: argparse.Namespace) -> int:
     paths = ensure_managed_layout(_repo_root())
     target = write_include(paths)
@@ -101,6 +177,27 @@ def main(argv: list[str] | None = None) -> int:
     inspect = sub.add_parser("inspect", help="print one request as JSON")
     inspect.add_argument("request_id")
     inspect.set_defaults(func=cmd_inspect)
+
+    new = sub.add_parser("new", help="stage a manual-add request")
+    new.add_argument("recipe_name")
+    new.add_argument("--command", required=True, help="recipe command body")
+    new.add_argument("--desc", default="", help="optional @desc doc text")
+    new.add_argument("--params", default="", help="optional recipe parameter list")
+    new.add_argument("--author", default="", help="operator label for the request")
+    new.add_argument("--review-notes", default="", help="freeform review notes")
+    new.set_defaults(func=cmd_new)
+
+    edit = sub.add_parser("edit", help="stage a manual-edit request from approved state")
+    edit.add_argument("recipe_name")
+    edit.add_argument("--author", default="", help="operator label for the request")
+    edit.add_argument("--review-notes", default="", help="freeform review notes")
+    edit.set_defaults(func=cmd_edit)
+
+    delete = sub.add_parser("delete", help="stage a manual-delete tombstone request")
+    delete.add_argument("recipe_name")
+    delete.add_argument("--author", default="", help="operator label for the request")
+    delete.add_argument("--review-notes", default="", help="freeform review notes")
+    delete.set_defaults(func=cmd_delete)
 
     sub.add_parser(
         "render-include",

--- a/just_for_agents/mutations.py
+++ b/just_for_agents/mutations.py
@@ -1,0 +1,141 @@
+"""Quarantined request materialization for managed recipe mutations."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from .managed_paths import ManagedPaths
+from .request_store import Request, RequestStore
+
+
+class MutationError(RuntimeError):
+    """Raised when a managed mutation request cannot be materialized."""
+
+
+def render_candidate_recipe(
+    recipe_name: str,
+    command: str,
+    *,
+    desc: str = "",
+    params: str = "",
+) -> str:
+    """Render one candidate managed recipe file."""
+
+    name = recipe_name.strip()
+    if not name:
+        raise MutationError("recipe name cannot be empty")
+    if not command:
+        raise MutationError("recipe command cannot be empty")
+
+    signature = name if not params.strip() else f"{name} {params.strip()}"
+    lines: list[str] = []
+    if desc:
+        lines.append(f"[doc({json.dumps(f'@desc {desc}')})]")
+    lines.append(f"{signature}:")
+    for line in command.splitlines():
+        lines.append(f"    {line}" if line else "    ")
+    return "\n".join(lines) + "\n"
+
+
+def approved_recipe_path(paths: ManagedPaths, recipe_name: str) -> Path:
+    """Return the governed approved path for one recipe name."""
+
+    return paths.approved_recipes_dir / f"{recipe_name}.just"
+
+
+def _write_request_file(path: Path, payload: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def create_new_request(
+    paths: ManagedPaths,
+    store: RequestStore,
+    *,
+    recipe_name: str,
+    command: str,
+    desc: str = "",
+    params: str = "",
+    author_label: str = "",
+    review_notes: str = "",
+) -> tuple[Request, Path]:
+    """Create a quarantined manual-add request with a candidate recipe."""
+
+    if approved_recipe_path(paths, recipe_name).exists():
+        raise MutationError(f"recipe {recipe_name!r} is already approved; use edit instead")
+
+    request = store.create(
+        source="manual-add",
+        target_recipes=[recipe_name],
+        author_label=author_label,
+        review_notes=review_notes,
+    )
+    candidate = store.request_dir(request.request_id) / "candidate.just"
+    return request, _write_request_file(
+        candidate,
+        render_candidate_recipe(recipe_name, command, desc=desc, params=params),
+    )
+
+
+def create_edit_request(
+    paths: ManagedPaths,
+    store: RequestStore,
+    *,
+    recipe_name: str,
+    author_label: str = "",
+    review_notes: str = "",
+) -> tuple[Request, Path]:
+    """Create a quarantined manual-edit request from approved state."""
+
+    approved = approved_recipe_path(paths, recipe_name)
+    if not approved.is_file():
+        raise MutationError(f"recipe {recipe_name!r} is not approved; cannot edit it")
+
+    request = store.create(
+        source="manual-edit",
+        target_recipes=[recipe_name],
+        author_label=author_label,
+        review_notes=review_notes,
+    )
+    candidate = store.request_dir(request.request_id) / "candidate.just"
+    shutil.copyfile(approved, candidate)
+    return request, candidate
+
+
+def create_delete_request(
+    paths: ManagedPaths,
+    store: RequestStore,
+    *,
+    recipe_name: str,
+    author_label: str = "",
+    review_notes: str = "",
+) -> tuple[Request, Path]:
+    """Create a quarantined manual-delete tombstone request."""
+
+    approved = approved_recipe_path(paths, recipe_name)
+    if not approved.is_file():
+        raise MutationError(f"recipe {recipe_name!r} is not approved; cannot delete it")
+
+    request = store.create(
+        source="manual-delete",
+        target_recipes=[recipe_name],
+        author_label=author_label,
+        review_notes=review_notes,
+    )
+    tombstone = store.request_dir(request.request_id) / "tombstone.json"
+    return request, _write_request_file(
+        tombstone,
+        json.dumps(
+            {
+                "action": "delete",
+                "recipe_name": recipe_name,
+                "approved_path": approved.name,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1,0 +1,113 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from just_for_agents.managed_paths import ensure_managed_layout
+from just_for_agents.mutations import (
+    MutationError,
+    create_delete_request,
+    create_edit_request,
+    create_new_request,
+)
+from just_for_agents.request_store import RequestStore
+
+
+def _setup(tmp: str):
+    paths = ensure_managed_layout(Path(tmp))
+    return paths, RequestStore(paths)
+
+
+class CreateNewRequestTests(unittest.TestCase):
+    def test_writes_candidate_without_touching_live_include(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup(tmp)
+
+            request, candidate = create_new_request(
+                paths,
+                store,
+                recipe_name="hello",
+                command="echo hi",
+                desc='Say "hi"',
+                params="name='world'",
+                author_label="operator",
+                review_notes="drafted by hand",
+            )
+
+            self.assertEqual(request.source, "manual-add")
+            self.assertEqual(request.target_recipes, ["hello"])
+            self.assertTrue(candidate.is_file())
+            self.assertEqual(
+                candidate.read_text(encoding="utf-8"),
+                '[doc("@desc Say \\"hi\\"")]\nhello name=\'world\':\n    echo hi\n',
+            )
+            self.assertNotIn("import ", paths.approved_include_file.read_text(encoding="utf-8"))
+
+            on_disk = json.loads(store.request_file(request.request_id).read_text(encoding="utf-8"))
+            self.assertEqual(on_disk["author_label"], "operator")
+            self.assertEqual(on_disk["review_notes"], "drafted by hand")
+
+    def test_rejects_duplicate_approved_recipe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup(tmp)
+            (paths.approved_recipes_dir / "hello.just").write_text("hello:\n    :\n", encoding="utf-8")
+
+            with self.assertRaises(MutationError):
+                create_new_request(paths, store, recipe_name="hello", command="echo hi")
+
+
+class CreateEditRequestTests(unittest.TestCase):
+    def test_clones_approved_recipe_into_quarantine(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup(tmp)
+            approved = paths.approved_recipes_dir / "hello.just"
+            approved.write_text("hello who='world':\n    echo {{who}}\n", encoding="utf-8")
+
+            request, candidate = create_edit_request(paths, store, recipe_name="hello")
+
+            self.assertEqual(request.source, "manual-edit")
+            self.assertEqual(candidate.read_text(encoding="utf-8"), approved.read_text(encoding="utf-8"))
+            self.assertEqual(approved.read_text(encoding="utf-8"), "hello who='world':\n    echo {{who}}\n")
+
+    def test_requires_approved_recipe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup(tmp)
+            with self.assertRaises(MutationError):
+                create_edit_request(paths, store, recipe_name="missing")
+
+
+class CreateDeleteRequestTests(unittest.TestCase):
+    def test_writes_tombstone_and_leaves_approved_recipe_in_place(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup(tmp)
+            approved = paths.approved_recipes_dir / "hello.just"
+            approved.write_text("hello:\n    echo hi\n", encoding="utf-8")
+
+            request, tombstone = create_delete_request(
+                paths,
+                store,
+                recipe_name="hello",
+                author_label="operator",
+            )
+
+            self.assertEqual(request.source, "manual-delete")
+            self.assertTrue(approved.is_file())
+            self.assertTrue(tombstone.is_file())
+            self.assertEqual(
+                json.loads(tombstone.read_text(encoding="utf-8")),
+                {
+                    "action": "delete",
+                    "approved_path": "hello.just",
+                    "recipe_name": "hello",
+                },
+            )
+
+    def test_requires_approved_recipe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup(tmp)
+            with self.assertRaises(MutationError):
+                create_delete_request(paths, store, recipe_name="missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stage managed new/edit/delete mutations as quarantined requests instead of touching the live Just surface
- route escalation guidance through the managed queue and update discovery/docs to match
- add mutation tests and changelog coverage for the new managed flow