### PR TITLE
Add managed dry-run review flows

### DIFF
--- a/.just-for-agents/managed.just
+++ b/.just-for-agents/managed.just
@@ -11,6 +11,18 @@
     python3 -m just_for_agents inspect "{{request_id}}"
 
 [no-cd]
+@dry-run request_id:
+    python3 -m just_for_agents dry-run "{{request_id}}"
+
+[no-cd]
+@review request_id:
+    python3 -m just_for_agents review "{{request_id}}"
+
+[no-cd]
+@dashboard:
+    python3 -m just_for_agents dashboard
+
+[no-cd]
 @new recipe_name command desc='' params='' author='' review_notes='':
     python3 -m just_for_agents new "{{recipe_name}}" --command "{{command}}" --desc "{{desc}}" --params "{{params}}" --author "{{author}}" --review-notes "{{review_notes}}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Added the managed-overlay foundation: a new `just_for_agents/` Python package (`managed_paths`, `request_store`, and a `python -m just_for_agents` CLI), a `.just-for-agents/managed.just` partition, and root-level `managed-bootstrap`, `managed-queue`, and `managed-inspect` recipes so quarantined requests land in a single auditable layout discoverable via `just schema` (JFA-81).
 - Added the approval core: `just_for_agents/projection.py` rebuilds `approved/includes/managed.just` deterministically, `just_for_agents/history.py` initializes a dedicated managed git repo and records one commit plus one decision-ledger entry per approval, and the new `managed-render-include` and `managed-approve` recipes plus an optional root-Justfile `import?` make approved managed recipes the only live include surface (JFA-82).
 - Added quarantined mutation staging for managed recipes: `managed-new`, `managed-edit`, and `managed-delete` now create request artifacts through `just_for_agents/mutations.py`, `just escalate` stages candidate capability work into the queue instead of publishing directly, and README/testing coverage documents the managed review flow (JFA-83).
+- Added dry-run/result capture plus browser-ready review and dashboard rendering for quarantined managed recipe requests, including new `managed-dry-run`, `managed-review`, and `managed-dashboard` operator commands on both the managed overlay and the public Just surface (JFA-84).
 
 ## [0.3.0] - 2026-04-30
 

--- a/Justfile
+++ b/Justfile
@@ -84,6 +84,26 @@ opencode-enable-exa-mcp:
 @managed-inspect request_id:
     just --justfile ./.just-for-agents/managed.just inspect "{{request_id}}"
 
+[doc("@desc Capture a quarantined dry-run preview for one request
+@param request_id The request id (e.g. req-20260501-001)
+@usage just managed-dry-run req-20260501-001
+@returns json")]
+@managed-dry-run request_id:
+    just --justfile ./.just-for-agents/managed.just dry-run "{{request_id}}"
+
+[doc("@desc Render an HTML review page for one quarantined request
+@param request_id The request id (e.g. req-20260501-001)
+@usage just managed-review req-20260501-001
+@returns json")]
+@managed-review request_id:
+    just --justfile ./.just-for-agents/managed.just review "{{request_id}}"
+
+[doc('@desc Render the managed operator dashboard and refresh its HTML companion
+@usage just managed-dashboard
+@returns text')]
+@managed-dashboard:
+    just --justfile ./.just-for-agents/managed.just dashboard
+
 [doc("@desc Stage a new managed recipe in the quarantined review queue
 @param recipe_name The managed recipe name to create
 @param command The recipe body command(s)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ just managed-edit recipe_name='hello'
 just managed-delete recipe_name='hello'
 just managed-queue
 just managed-inspect req-20260501-001
+just managed-dry-run req-20260501-001
+just managed-review req-20260501-001
+just managed-dashboard
 just managed-approve req-20260501-001 operator='you' rationale='reviewed'
 ```
 

--- a/just_for_agents/__init__.py
+++ b/just_for_agents/__init__.py
@@ -5,6 +5,13 @@ Hosts helpers for the managed recipe governance overlay: filesystem layout
 manual mutation staging (`mutations`), and approval/projection helpers.
 """
 
+from .dry_run import (
+    DryRunError,
+    dry_run_dir,
+    dry_run_result_file,
+    load_dry_run_result,
+    run_request_dry_run,
+)
 from .history import (
     ApprovalError,
     append_decision,
@@ -23,13 +30,23 @@ from .mutations import (
 )
 from .projection import render_include, write_include
 from .request_store import Request, RequestStore
+from .review import (
+    ReviewError,
+    dashboard_file,
+    render_dashboard_text,
+    request_review_file,
+    write_dashboard,
+    write_request_review,
+)
 
 __all__ = [
     "ApprovalError",
+    "DryRunError",
     "ManagedPaths",
     "MutationError",
     "Request",
     "RequestStore",
+    "ReviewError",
     "approved_recipe_path",
     "append_decision",
     "approve_request",
@@ -37,9 +54,18 @@ __all__ = [
     "create_delete_request",
     "create_edit_request",
     "create_new_request",
+    "dashboard_file",
+    "dry_run_dir",
+    "dry_run_result_file",
     "ensure_managed_layout",
     "ensure_managed_repo",
+    "load_dry_run_result",
     "render_candidate_recipe",
+    "render_dashboard_text",
     "render_include",
+    "request_review_file",
+    "run_request_dry_run",
     "write_include",
+    "write_dashboard",
+    "write_request_review",
 ]

--- a/just_for_agents/__main__.py
+++ b/just_for_agents/__main__.py
@@ -8,6 +8,9 @@ Exposes the minimal surface needed by the root Justfile's `managed-*` recipes:
 * ``new <name>`` — stage a manual-add request with a candidate recipe body.
 * ``edit <name>`` — clone one approved managed recipe into quarantine.
 * ``delete <name>`` — stage a tombstone request for one approved recipe.
+* ``dry-run <request_id>`` — capture a quarantined recipe dry-run preview.
+* ``review <request_id>`` — render one browser-ready review page.
+* ``dashboard`` — print a terminal dashboard and refresh the HTML companion.
 * ``render-include`` — rebuild ``approved/includes/managed.just`` from approved/recipes/.
 * ``approve <request_id>`` — approve a quarantined request, project, commit, ledger.
 """
@@ -19,6 +22,7 @@ import json
 import sys
 from pathlib import Path
 
+from .dry_run import DryRunError, run_request_dry_run
 from .history import ApprovalError, approve_request
 from .managed_paths import ensure_managed_layout
 from .mutations import (
@@ -29,6 +33,7 @@ from .mutations import (
 )
 from .projection import write_include
 from .request_store import RequestStore
+from .review import ReviewError, render_dashboard_text, write_dashboard, write_request_review
 
 
 def _repo_root() -> Path:
@@ -148,6 +153,42 @@ def cmd_render_include(_args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_dry_run(args: argparse.Namespace) -> int:
+    paths = ensure_managed_layout(_repo_root())
+    store = RequestStore(paths)
+    try:
+        payload = run_request_dry_run(paths, store, args.request_id)
+    except DryRunError as exc:
+        print(f"dry-run failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_review(args: argparse.Namespace) -> int:
+    paths = ensure_managed_layout(_repo_root())
+    store = RequestStore(paths)
+    try:
+        payload = write_request_review(paths, store, args.request_id)
+    except ReviewError as exc:
+        print(f"review failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_dashboard(_args: argparse.Namespace) -> int:
+    paths = ensure_managed_layout(_repo_root())
+    store = RequestStore(paths)
+    try:
+        write_dashboard(paths, store)
+        print(render_dashboard_text(paths, store), end="")
+    except ReviewError as exc:
+        print(f"dashboard failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def cmd_approve(args: argparse.Namespace) -> int:
     paths = ensure_managed_layout(_repo_root())
     store = RequestStore(paths)
@@ -198,6 +239,22 @@ def main(argv: list[str] | None = None) -> int:
     delete.add_argument("--author", default="", help="operator label for the request")
     delete.add_argument("--review-notes", default="", help="freeform review notes")
     delete.set_defaults(func=cmd_delete)
+
+    dry_run = sub.add_parser(
+        "dry-run",
+        help="capture a quarantined dry-run preview for one request",
+    )
+    dry_run.add_argument("request_id")
+    dry_run.set_defaults(func=cmd_dry_run)
+
+    review = sub.add_parser("review", help="render one request review page")
+    review.add_argument("request_id")
+    review.set_defaults(func=cmd_review)
+
+    sub.add_parser(
+        "dashboard",
+        help="render the managed operator dashboard and refresh the HTML companion",
+    ).set_defaults(func=cmd_dashboard)
 
     sub.add_parser(
         "render-include",

--- a/just_for_agents/dry_run.py
+++ b/just_for_agents/dry_run.py
@@ -1,0 +1,248 @@
+"""Dry-run execution for quarantined managed recipe requests."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .managed_paths import ManagedPaths
+from .request_store import Request, RequestStore
+
+
+class DryRunError(RuntimeError):
+    """Raised when a managed request dry-run cannot be completed."""
+
+
+def dry_run_dir(paths: ManagedPaths, request_id: str) -> Path:
+    """Return the artifact directory for one request's dry-run output."""
+
+    return paths.quarantine_requests_dir / request_id / "dry-run"
+
+
+def dry_run_result_file(paths: ManagedPaths, request_id: str) -> Path:
+    """Return the JSON result file for one request's dry-run output."""
+
+    return dry_run_dir(paths, request_id) / "result.json"
+
+
+def load_dry_run_result(paths: ManagedPaths, request_id: str) -> dict[str, Any] | None:
+    """Load one request's dry-run result payload if it exists."""
+
+    result_file = dry_run_result_file(paths, request_id)
+    if not result_file.is_file():
+        return None
+    return json.loads(result_file.read_text(encoding="utf-8"))
+
+
+def _relative_import(from_dir: Path, target: Path) -> str:
+    return Path(os.path.relpath(target, start=from_dir)).as_posix()
+
+
+def _candidate_file(paths: ManagedPaths, request: Request) -> Path:
+    return paths.quarantine_requests_dir / request.request_id / "candidate.just"
+
+
+def _tombstone_file(paths: ManagedPaths, request: Request) -> Path:
+    return paths.quarantine_requests_dir / request.request_id / "tombstone.json"
+
+
+def _strip_managed_include(root_justfile: Path) -> str:
+    source = root_justfile.read_text(encoding="utf-8")
+    filtered = [
+        line
+        for line in source.splitlines()
+        if "managed/approved/includes/managed.just" not in line
+    ]
+    return "\n".join(filtered) + ("\n" if source.endswith("\n") else "")
+
+
+def _approved_recipe_imports(paths: ManagedPaths, excluded: set[str]) -> list[Path]:
+    return [
+        recipe
+        for recipe in sorted(paths.approved_recipes_dir.glob("*.just"))
+        if recipe.stem not in excluded
+    ]
+
+
+def _write_session_justfile(paths: ManagedPaths, request: Request, target_dir: Path) -> tuple[Path, Path]:
+    root_copy = target_dir / "root.just"
+    root_copy.write_text(_strip_managed_include(paths.repo_root / "Justfile"), encoding="utf-8")
+
+    session_justfile = target_dir / "session.just"
+    lines = [f'import "{root_copy.name}"']
+    for recipe in _approved_recipe_imports(paths, set(request.target_recipes)):
+        lines.append(f'import "{_relative_import(target_dir, recipe)}"')
+
+    candidate = _candidate_file(paths, request)
+    if candidate.is_file():
+        lines.append(f'import "{_relative_import(target_dir, candidate)}"')
+
+    session_justfile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return root_copy, session_justfile
+
+
+def _run_just_dry_run(paths: ManagedPaths, session_justfile: Path, recipe_name: str) -> dict[str, Any]:
+    command = [
+        "just",
+        "--working-directory",
+        str(paths.repo_root),
+        "--justfile",
+        str(session_justfile),
+        "--dry-run",
+        recipe_name,
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    status = "passed" if result.returncode == 0 else "failed"
+    preview = result.stdout + result.stderr
+    return {
+        "recipe_name": recipe_name,
+        "status": status,
+        "exit_code": result.returncode,
+        "command": shlex.join(command),
+        "preview": preview,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _skipped_recipe_result(recipe_name: str, reason: str) -> dict[str, Any]:
+    return {
+        "recipe_name": recipe_name,
+        "status": "skipped",
+        "exit_code": 0,
+        "command": "",
+        "preview": "",
+        "stdout": "",
+        "stderr": "",
+        "reason": reason,
+    }
+
+
+def _summarize_recipe_result(result: dict[str, Any]) -> str:
+    recipe_name = result["recipe_name"]
+    status = result["status"]
+    if status == "passed":
+        return recipe_name
+    if status == "failed":
+        return f"{recipe_name} (exit {result['exit_code']})"
+    return f"{recipe_name} ({result.get('reason', 'skipped')})"
+
+
+def _build_summary(recipe_results: list[dict[str, Any]]) -> tuple[str, str]:
+    if any(result["status"] == "failed" for result in recipe_results):
+        failed = ", ".join(
+            _summarize_recipe_result(result)
+            for result in recipe_results
+            if result["status"] == "failed"
+        )
+        return "failed", f"dry-run failed for {failed}"
+
+    if recipe_results and all(result["status"] == "skipped" for result in recipe_results):
+        skipped = ", ".join(_summarize_recipe_result(result) for result in recipe_results)
+        return "skipped", f"dry-run skipped for {skipped}"
+
+    passed = ", ".join(
+        _summarize_recipe_result(result)
+        for result in recipe_results
+        if result["status"] == "passed"
+    )
+    return "passed", f"dry-run passed for {passed}"
+
+
+def _aggregate_stream(recipe_results: list[dict[str, Any]], key: str) -> str:
+    blocks: list[str] = []
+    for result in recipe_results:
+        value = result.get(key, "")
+        if not value:
+            continue
+        header = f"$ {result['command']}" if result.get("command") else result["recipe_name"]
+        blocks.append(f"{header}\n{value.rstrip()}")
+    return ("\n\n".join(blocks) + "\n") if blocks else ""
+
+
+def run_request_dry_run(
+    paths: ManagedPaths,
+    store: RequestStore,
+    request_id: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Run and persist a dry-run preview for one quarantined request."""
+
+    request = store.get(request_id)
+    if request is None:
+        raise DryRunError(f"unknown request: {request_id}")
+    if request.status != "quarantined":
+        raise DryRunError(
+            f"request {request_id} is {request.status!r}; only quarantined requests support dry-run"
+        )
+    if not request.target_recipes:
+        raise DryRunError(f"request {request_id} has no target_recipes to dry-run")
+
+    dry_run_root = dry_run_dir(paths, request_id)
+    dry_run_root.mkdir(parents=True, exist_ok=True)
+
+    candidate = _candidate_file(paths, request)
+    tombstone = _tombstone_file(paths, request)
+    root_copy: Path | None = None
+    session_justfile: Path | None = None
+
+    if candidate.is_file():
+        root_copy, session_justfile = _write_session_justfile(paths, request, dry_run_root)
+        recipe_results = [
+            _run_just_dry_run(paths, session_justfile, recipe_name)
+            for recipe_name in request.target_recipes
+        ]
+    elif tombstone.is_file():
+        recipe_results = [
+            _skipped_recipe_result(
+                recipe_name,
+                "delete request has no candidate recipe body",
+            )
+            for recipe_name in request.target_recipes
+        ]
+    else:
+        raise DryRunError(
+            f"request {request_id} has neither candidate.just nor tombstone.json to review"
+        )
+
+    status, summary = _build_summary(recipe_results)
+    stdout_text = _aggregate_stream(recipe_results, "stdout")
+    stderr_text = _aggregate_stream(recipe_results, "stderr")
+    preview_text = _aggregate_stream(recipe_results, "preview")
+    preview_path = dry_run_root / "preview.txt"
+    stdout_path = dry_run_root / "stdout.txt"
+    stderr_path = dry_run_root / "stderr.txt"
+    preview_path.write_text(preview_text, encoding="utf-8")
+    stdout_path.write_text(stdout_text, encoding="utf-8")
+    stderr_path.write_text(stderr_text, encoding="utf-8")
+
+    moment = (now or datetime.now(timezone.utc)).replace(microsecond=0)
+    payload: dict[str, Any] = {
+        "request_id": request_id,
+        "generated_at": moment.isoformat(),
+        "status": status,
+        "summary": summary,
+        "dry_run_dir": str(dry_run_root),
+        "result_path": str(dry_run_result_file(paths, request_id)),
+        "preview_path": str(preview_path),
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+        "root_justfile_path": str(root_copy) if root_copy else "",
+        "session_justfile_path": str(session_justfile) if session_justfile else "",
+        "recipe_results": recipe_results,
+    }
+    dry_run_result_file(paths, request_id).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    request.dry_run_summary = summary
+    request.updated_at = moment.isoformat()
+    store.save(request)
+    return payload

--- a/just_for_agents/request_store.py
+++ b/just_for_agents/request_store.py
@@ -62,6 +62,17 @@ class RequestStore:
     def request_file(self, request_id: str) -> Path:
         return self.request_dir(request_id) / "request.json"
 
+    def save(self, request: Request) -> Request:
+        """Persist a request object back to disk."""
+
+        directory = self.request_dir(request.request_id)
+        directory.mkdir(parents=True, exist_ok=True)
+        self.request_file(request.request_id).write_text(
+            json.dumps(request.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return request
+
     def create(
         self,
         *,
@@ -94,11 +105,7 @@ class RequestStore:
 
         directory = self.request_dir(request_id)
         directory.mkdir(parents=True, exist_ok=False)
-        self.request_file(request_id).write_text(
-            json.dumps(request.to_dict(), indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        return request
+        return self.save(request)
 
     def get(self, request_id: str) -> Request | None:
         path = self.request_file(request_id)

--- a/just_for_agents/review.py
+++ b/just_for_agents/review.py
@@ -1,0 +1,380 @@
+"""HTML review and dashboard rendering for managed recipe requests."""
+
+from __future__ import annotations
+
+import difflib
+import json
+import tomllib
+from datetime import datetime, timezone
+from html import escape
+from pathlib import Path
+from typing import Any
+
+from .dry_run import load_dry_run_result
+from .managed_paths import ManagedPaths
+from .request_store import RequestStore
+
+
+class ReviewError(RuntimeError):
+    """Raised when a managed review page cannot be rendered."""
+
+
+def request_review_file(paths: ManagedPaths, request_id: str) -> Path:
+    """Return the request-scoped HTML review file path."""
+
+    return paths.quarantine_requests_dir / request_id / "review.html"
+
+
+def dashboard_file(paths: ManagedPaths) -> Path:
+    """Return the managed operator dashboard HTML file path."""
+
+    return paths.managed_root / "dashboard.html"
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _decision_rows(paths: ManagedPaths) -> list[dict[str, Any]]:
+    if not paths.decisions_log.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in paths.decisions_log.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def _latest_approval_by_recipe(paths: ManagedPaths) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for row in _decision_rows(paths):
+        if row.get("decision") != "approve":
+            continue
+        for recipe_name in row.get("target_recipes", []):
+            latest[recipe_name] = row
+    return latest
+
+
+def _pending_requests_by_recipe(store: RequestStore) -> dict[str, list[str]]:
+    pending: dict[str, list[str]] = {}
+    for request in store.list_quarantined():
+        for recipe_name in request.target_recipes:
+            pending.setdefault(recipe_name, []).append(request.request_id)
+    return pending
+
+
+def _dry_run_state(paths: ManagedPaths, request_id: str, summary: str) -> str:
+    result = load_dry_run_result(paths, request_id)
+    if result is not None:
+        return result["status"]
+    return "pending" if not summary else "recorded"
+
+
+def _settings_rows(paths: ManagedPaths) -> list[tuple[str, str, str]]:
+    payload = tomllib.loads(paths.config_file.read_text(encoding="utf-8"))
+    rows: list[tuple[str, str, str]] = []
+    for section_name in sorted(payload):
+        section = payload[section_name]
+        if not isinstance(section, dict):
+            rows.append(("", section_name, str(section)))
+            continue
+        for key in sorted(section):
+            rows.append((section_name, key, str(section[key])))
+    return rows
+
+
+def _page(title: str, body: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{escape(title)}</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 2rem auto; max-width: 1100px; padding: 0 1rem; line-height: 1.5; color: #1f2933; }}
+    h1, h2, h3 {{ color: #102a43; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 1rem 0 2rem; }}
+    th, td {{ border: 1px solid #d9e2ec; padding: 0.5rem 0.75rem; text-align: left; vertical-align: top; }}
+    th {{ background: #f0f4f8; }}
+    pre {{ background: #f8fafc; border: 1px solid #d9e2ec; padding: 1rem; overflow-x: auto; }}
+    .summary {{ background: #f0f4f8; border-left: 4px solid #486581; padding: 0.75rem 1rem; margin: 1rem 0 2rem; }}
+    .status-pill {{ display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; background: #d9e2ec; }}
+    .diff {{ overflow-x: auto; }}
+    .diff table {{ font-family: ui-monospace, SFMono-Regular, monospace; font-size: 0.9rem; }}
+  </style>
+</head>
+<body>
+{body}
+</body>
+</html>
+"""
+
+
+def write_request_review(
+    paths: ManagedPaths,
+    store: RequestStore,
+    request_id: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Render and persist one request's HTML review page."""
+
+    request = store.get(request_id)
+    if request is None:
+        raise ReviewError(f"unknown request: {request_id}")
+
+    request_dir = store.request_dir(request_id)
+    review_path = request_review_file(paths, request_id)
+    review_path.parent.mkdir(parents=True, exist_ok=True)
+    candidate = _read_text(request_dir / "candidate.just")
+    tombstone = _read_text(request_dir / "tombstone.json")
+    approved_snapshots = {
+        recipe_name: _read_text(paths.approved_recipes_dir / f"{recipe_name}.just")
+        for recipe_name in request.target_recipes
+    }
+    dry_run = load_dry_run_result(paths, request_id)
+
+    diff_html = ""
+    if candidate and len(request.target_recipes) == 1:
+        recipe_name = request.target_recipes[0]
+        approved = approved_snapshots.get(recipe_name, "")
+        if approved:
+            diff_html = difflib.HtmlDiff(wrapcolumn=88).make_table(
+                approved.splitlines(),
+                candidate.splitlines(),
+                fromdesc=f"approved/{recipe_name}.just",
+                todesc="candidate.just",
+                context=True,
+                numlines=3,
+            )
+
+    dry_run_html = "<p>No dry-run has been recorded yet.</p>"
+    if dry_run is not None:
+        rows = "".join(
+            f"<tr><td>{escape(result['recipe_name'])}</td><td>{escape(result['status'])}</td><td>{result['exit_code']}</td></tr>"
+            for result in dry_run["recipe_results"]
+        )
+        details = "".join(
+            "<h3>{name}</h3><p><strong>Status:</strong> {status}</p>{reason}<p><strong>Command:</strong> <code>{command}</code></p><h4>preview</h4><pre>{preview}</pre><h4>stdout</h4><pre>{stdout}</pre><h4>stderr</h4><pre>{stderr}</pre>".format(
+                name=escape(result["recipe_name"]),
+                status=escape(result["status"]),
+                reason=(
+                    f"<p><strong>Reason:</strong> {escape(result['reason'])}</p>"
+                    if result.get("reason")
+                    else ""
+                ),
+                command=escape(result.get("command", "")),
+                preview=escape(result.get("preview", "")),
+                stdout=escape(result.get("stdout", "")),
+                stderr=escape(result.get("stderr", "")),
+            )
+            for result in dry_run["recipe_results"]
+        )
+        dry_run_html = (
+            f"<div class=\"summary\"><strong>{escape(dry_run['summary'])}</strong><br>"
+            f"Generated at {escape(dry_run['generated_at'])}</div>"
+            f"<table><thead><tr><th>Recipe</th><th>Status</th><th>Exit</th></tr></thead><tbody>{rows}</tbody></table>"
+            f"{details}"
+        )
+
+    approved_blocks = "".join(
+        f"<h3>{escape(recipe_name)}</h3><pre>{escape(body or '(not currently approved)')}</pre>"
+        for recipe_name, body in approved_snapshots.items()
+    )
+    body = f"""
+<h1>Managed request review: {escape(request_id)}</h1>
+<div class="summary">
+  <strong>Status:</strong> <span class="status-pill">{escape(request.status)}</span><br>
+  <strong>Targets:</strong> {escape(', '.join(request.target_recipes) or '-')}<br>
+  <strong>Source:</strong> {escape(request.source)}<br>
+  <strong>Dry-run summary:</strong> {escape(request.dry_run_summary or 'pending')}
+</div>
+
+<h2>Metadata</h2>
+<table>
+  <tbody>
+    <tr><th>Request ID</th><td>{escape(request.request_id)}</td></tr>
+    <tr><th>Author</th><td>{escape(request.author_label or '-')}</td></tr>
+    <tr><th>Created</th><td>{escape(request.created_at)}</td></tr>
+    <tr><th>Updated</th><td>{escape(request.updated_at)}</td></tr>
+    <tr><th>Review notes</th><td>{escape(request.review_notes or '-')}</td></tr>
+    <tr><th>Risk flags</th><td>{escape(', '.join(request.risk_flags) or '-')}</td></tr>
+  </tbody>
+</table>
+
+<h2>Candidate artifact</h2>
+<pre>{escape(candidate or tombstone or '(no candidate artifact recorded)')}</pre>
+
+<h2>Approved state</h2>
+{approved_blocks}
+
+<h2>Diff</h2>
+{f'<div class="diff">{diff_html}</div>' if diff_html else '<p>No side-by-side diff is available for this request.</p>'}
+
+<h2>Dry-run</h2>
+{dry_run_html}
+"""
+    review_path.write_text(
+        _page(f"Managed request review {request_id}", body),
+        encoding="utf-8",
+    )
+    moment = (now or datetime.now(timezone.utc)).replace(microsecond=0)
+    return {
+        "request_id": request_id,
+        "review_path": str(review_path),
+        "generated_at": moment.isoformat(),
+        "dry_run_result_path": (
+            str((request_dir / "dry-run" / "result.json"))
+            if (request_dir / "dry-run" / "result.json").is_file()
+            else ""
+        ),
+    }
+
+
+def render_dashboard_text(paths: ManagedPaths, store: RequestStore) -> str:
+    """Render the terminal-oriented managed operator dashboard summary."""
+
+    queue_rows = [
+        (
+            request.request_id,
+            request.source,
+            ",".join(request.target_recipes) or "-",
+            _dry_run_state(paths, request.request_id, request.dry_run_summary),
+            request.dry_run_summary or "-",
+        )
+        for request in store.list_quarantined()
+    ]
+    approvals = _latest_approval_by_recipe(paths)
+    pending_by_recipe = _pending_requests_by_recipe(store)
+    library_rows = []
+    for recipe in sorted(paths.approved_recipes_dir.glob("*.just")):
+        latest = approvals.get(recipe.stem, {})
+        library_rows.append(
+            (
+                recipe.stem,
+                latest.get("request_id", "-"),
+                latest.get("managed_commit", "-"),
+                ",".join(pending_by_recipe.get(recipe.stem, [])) or "-",
+            )
+        )
+
+    lines = [
+        "Queue",
+        "-----",
+    ]
+    if queue_rows:
+        lines.extend(
+            f"{request_id}\t{source}\t{targets}\t{dry_run_state}\t{summary}"
+            for request_id, source, targets, dry_run_state, summary in queue_rows
+        )
+    else:
+        lines.append("(no quarantined requests)")
+
+    lines.extend(["", "Library", "-------"])
+    if library_rows:
+        lines.extend(
+            f"{name}\tlatest={request_id}\tcommit={commit}\tpending={pending}"
+            for name, request_id, commit, pending in library_rows
+        )
+    else:
+        lines.append("(no approved managed recipes)")
+
+    lines.extend(["", "Settings", "--------"])
+    settings = _settings_rows(paths)
+    if settings:
+        lines.extend(
+            f"[{section}] {key} = {value}" if section else f"{key} = {value}"
+            for section, key, value in settings
+        )
+    else:
+        lines.append("(no settings)")
+
+    lines.extend(["", f"HTML: {dashboard_file(paths)}"])
+    return "\n".join(lines) + "\n"
+
+
+def write_dashboard(
+    paths: ManagedPaths,
+    store: RequestStore,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Render and persist the operator dashboard HTML companion."""
+
+    queue_rows = [
+        (
+            request.request_id,
+            request.source,
+            ",".join(request.target_recipes) or "-",
+            _dry_run_state(paths, request.request_id, request.dry_run_summary),
+            request.dry_run_summary or "-",
+        )
+        for request in store.list_quarantined()
+    ]
+    approvals = _latest_approval_by_recipe(paths)
+    pending_by_recipe = _pending_requests_by_recipe(store)
+    library_rows = []
+    for recipe in sorted(paths.approved_recipes_dir.glob("*.just")):
+        latest = approvals.get(recipe.stem, {})
+        library_rows.append(
+            (
+                recipe.stem,
+                latest.get("request_id", "-"),
+                latest.get("managed_commit", "-"),
+                ",".join(pending_by_recipe.get(recipe.stem, [])) or "-",
+            )
+        )
+
+    queue_table = (
+        "".join(
+            f"<tr><td>{escape(request_id)}</td><td>{escape(source)}</td><td>{escape(targets)}</td><td>{escape(dry_run_state)}</td><td>{escape(summary)}</td></tr>"
+            for request_id, source, targets, dry_run_state, summary in queue_rows
+        )
+        or "<tr><td colspan=\"5\">(no quarantined requests)</td></tr>"
+    )
+    library_table = (
+        "".join(
+            f"<tr><td>{escape(name)}</td><td>{escape(request_id)}</td><td>{escape(commit)}</td><td>{escape(pending)}</td></tr>"
+            for name, request_id, commit, pending in library_rows
+        )
+        or "<tr><td colspan=\"4\">(no approved managed recipes)</td></tr>"
+    )
+    settings_table = (
+        "".join(
+            f"<tr><td>{escape(section or '-')}</td><td>{escape(key)}</td><td>{escape(value)}</td></tr>"
+            for section, key, value in _settings_rows(paths)
+        )
+        or "<tr><td colspan=\"3\">(no settings)</td></tr>"
+    )
+    body = f"""
+<h1>Managed operator dashboard</h1>
+<div class="summary">Queue/library/settings snapshot for the managed recipe governance overlay.</div>
+
+<h2>Queue</h2>
+<table>
+  <thead><tr><th>Request</th><th>Source</th><th>Targets</th><th>Dry-run</th><th>Summary</th></tr></thead>
+  <tbody>{queue_table}</tbody>
+</table>
+
+<h2>Library</h2>
+<table>
+  <thead><tr><th>Recipe</th><th>Latest approval</th><th>Managed commit</th><th>Pending requests</th></tr></thead>
+  <tbody>{library_table}</tbody>
+</table>
+
+<h2>Settings</h2>
+<table>
+  <thead><tr><th>Section</th><th>Key</th><th>Value</th></tr></thead>
+  <tbody>{settings_table}</tbody>
+</table>
+"""
+    target = dashboard_file(paths)
+    target.write_text(_page("Managed operator dashboard", body), encoding="utf-8")
+    moment = (now or datetime.now(timezone.utc)).replace(microsecond=0)
+    return {
+        "dashboard_path": str(target),
+        "generated_at": moment.isoformat(),
+        "queue_count": len(queue_rows),
+        "approved_recipe_count": len(library_rows),
+    }

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,79 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from just_for_agents.dry_run import load_dry_run_result, run_request_dry_run
+from just_for_agents.managed_paths import ensure_managed_layout
+from just_for_agents.request_store import RequestStore
+
+
+def _setup_repo(tmp: str):
+    repo_root = Path(tmp)
+    repo_root.joinpath("Justfile").write_text(
+        "import? '.just-for-agents/managed/approved/includes/managed.just'\n\nhelper:\n    echo helper\n",
+        encoding="utf-8",
+    )
+    paths = ensure_managed_layout(repo_root)
+    return paths, RequestStore(paths)
+
+
+class RunRequestDryRunTests(unittest.TestCase):
+    def test_records_candidate_dry_run_and_updates_request_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            request = store.create(source="manual-add", target_recipes=["hello"])
+            candidate = paths.quarantine_requests_dir / request.request_id / "candidate.just"
+            candidate.write_text("hello:\n    echo hi\n", encoding="utf-8")
+
+            payload = run_request_dry_run(paths, store, request.request_id)
+
+            self.assertEqual(payload["status"], "passed")
+            self.assertIn("dry-run passed for hello", payload["summary"])
+            self.assertTrue(Path(payload["result_path"]).is_file())
+            self.assertTrue(Path(payload["preview_path"]).is_file())
+            self.assertIn("echo hi", Path(payload["preview_path"]).read_text(encoding="utf-8"))
+
+            on_disk = json.loads(store.request_file(request.request_id).read_text(encoding="utf-8"))
+            self.assertEqual(on_disk["dry_run_summary"], payload["summary"])
+            self.assertEqual(load_dry_run_result(paths, request.request_id)["status"], "passed")
+
+    def test_edit_request_dry_run_uses_candidate_body_not_live_recipe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            (paths.approved_recipes_dir / "hello.just").write_text(
+                "hello:\n    echo approved\n", encoding="utf-8"
+            )
+            request = store.create(source="manual-edit", target_recipes=["hello"])
+            candidate = paths.quarantine_requests_dir / request.request_id / "candidate.just"
+            candidate.write_text("hello:\n    echo candidate\n", encoding="utf-8")
+
+            payload = run_request_dry_run(paths, store, request.request_id)
+
+            preview = Path(payload["preview_path"]).read_text(encoding="utf-8")
+            self.assertEqual(payload["status"], "passed")
+            self.assertIn("echo candidate", preview)
+            self.assertNotIn("echo approved", preview)
+
+    def test_delete_request_records_skipped_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            (paths.approved_recipes_dir / "hello.just").write_text(
+                "hello:\n    echo live\n", encoding="utf-8"
+            )
+            request = store.create(source="manual-delete", target_recipes=["hello"])
+            tombstone = paths.quarantine_requests_dir / request.request_id / "tombstone.json"
+            tombstone.write_text(
+                json.dumps({"action": "delete", "recipe_name": "hello"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            payload = run_request_dry_run(paths, store, request.request_id)
+
+            self.assertEqual(payload["status"], "skipped")
+            self.assertIn("delete request has no candidate recipe body", payload["summary"])
+            self.assertEqual(payload["recipe_results"][0]["status"], "skipped")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,87 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from just_for_agents.dry_run import run_request_dry_run
+from just_for_agents.history import append_decision
+from just_for_agents.managed_paths import ensure_managed_layout
+from just_for_agents.request_store import RequestStore
+from just_for_agents.review import render_dashboard_text, write_dashboard, write_request_review
+
+
+def _setup_repo(tmp: str):
+    repo_root = Path(tmp)
+    repo_root.joinpath("Justfile").write_text(
+        "import? '.just-for-agents/managed/approved/includes/managed.just'\n",
+        encoding="utf-8",
+    )
+    paths = ensure_managed_layout(repo_root)
+    return paths, RequestStore(paths)
+
+
+class RequestReviewTests(unittest.TestCase):
+    def test_write_request_review_renders_html_with_diff_and_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            (paths.approved_recipes_dir / "hello.just").write_text(
+                "hello:\n    echo approved\n", encoding="utf-8"
+            )
+            request = store.create(
+                source="manual-edit",
+                target_recipes=["hello"],
+                author_label="operator",
+                review_notes="check updated command",
+            )
+            candidate = paths.quarantine_requests_dir / request.request_id / "candidate.just"
+            candidate.write_text("hello:\n    echo candidate\n", encoding="utf-8")
+            run_request_dry_run(paths, store, request.request_id)
+
+            payload = write_request_review(paths, store, request.request_id)
+
+            html = Path(payload["review_path"]).read_text(encoding="utf-8")
+            self.assertIn("Managed request review", html)
+            self.assertIn(request.request_id, html)
+            self.assertIn("echo approved", html)
+            self.assertIn("echo candidate", html)
+            self.assertIn("dry-run passed for hello", html)
+            self.assertIn("candidate.just", html)
+
+
+class DashboardTests(unittest.TestCase):
+    def test_dashboard_lists_queue_library_and_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            (paths.approved_recipes_dir / "hello.just").write_text(
+                "hello:\n    echo live\n", encoding="utf-8"
+            )
+            append_decision(
+                paths,
+                {
+                    "request_id": "req-20260501-001",
+                    "decision": "approve",
+                    "managed_commit": "abc1234",
+                    "target_recipes": ["hello"],
+                },
+            )
+            request = store.create(source="manual-add", target_recipes=["world"])
+            candidate = paths.quarantine_requests_dir / request.request_id / "candidate.just"
+            candidate.write_text("world:\n    echo queued\n", encoding="utf-8")
+            run_request_dry_run(paths, store, request.request_id)
+
+            text = render_dashboard_text(paths, store)
+            payload = write_dashboard(paths, store)
+            html = Path(payload["dashboard_path"]).read_text(encoding="utf-8")
+
+            self.assertIn("Queue", text)
+            self.assertIn(request.request_id, text)
+            self.assertIn("Library", text)
+            self.assertIn("hello", text)
+            self.assertIn("[approval] allow_self_approval = True", text)
+            self.assertIn("Managed operator dashboard", html)
+            self.assertIn("abc1234", html)
+            self.assertIn(request.request_id, html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add quarantined managed dry-run artifact capture and summary persistence
- add HTML request review and operator dashboard rendering
- expose managed-dry-run, managed-review, and managed-dashboard on the managed overlay and root Just surface

## Testing
- python3 -m unittest tests.test_dry_run tests.test_review -v
- python3 -m unittest tests.test_request_store tests.test_managed_paths tests.test_mutations tests.test_projection tests.test_history tests.test_dry_run tests.test_review -v
- just schema
