### PR TITLE
Set schema as explicit default recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Added dry-run/result capture plus browser-ready review and dashboard rendering for quarantined managed recipe requests, including new `managed-dry-run`, `managed-review`, and `managed-dashboard` operator commands on both the managed overlay and the public Just surface (JFA-84).
 - Hardened the managed governance flow so bootstrap guidance now explains the quarantine-first posture, the dashboard/review surfaces report managed-history drift, and `managed-approve` / `managed-render-include` refuse to overwrite direct edits under the governed approved surface (JFA-85).
 
+### Fixed
+
+- Set the agent-facing `schema` recipe as the explicit `[default]` entrypoint so bare `just` deterministically returns the machine-readable discovery manifest without depending on recipe order, and documented `just --list` as the human-readable listing path.
+
 ## [0.3.0] - 2026-04-30
 
 ### Changed

--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@
 # The include is regenerated from approved/recipes/ on every approval; the
 # import is optional so a fresh checkout works before `just managed-bootstrap`.
 import? '.just-for-agents/managed/approved/includes/managed.just'
-
+[default]
 [doc('@desc Generate a JSON tool schema from the Justfile
 @usage Use this to get a machine-readable map of available tools.
 @returns json')]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Release notes live in `CHANGELOG.md`, and git tags use the matching `vX.Y.Z` for
 
 To ensure interoperability, just-for-agents follows these conventions:
 
-* **The Discovery Pattern:** Agents should always run just \--list or just-for-agents \--scan upon entering a directory.  
+* **The Discovery Pattern:** Agents should start with bare `just` (explicitly bound to `just schema`) for machine-readable discovery, and use `just --list` when they need the human-readable recipe catalog.  
 * **The Argument Contract:** All variables in recipes should have sensible defaults or clear descriptions in the comments.  
 * **Safety First:** Destructive commands (e.g., rm, drop-db) must be explicitly tagged with @danger in the comments to trigger agent confirmation.
 

--- a/concept.md
+++ b/concept.md
@@ -30,16 +30,17 @@ list-containers profile="dev":
 ```
 
 ## 3. The Discovery Loop (Output-Based)
-Instead of parsing the `Justfile` source, the agent leverages `just`'s own reflection. Running `just` (or `just --list`) produces a machine-readable stream where metadata is prefixed by `#`.
+Instead of parsing the `Justfile` source, the agent leverages `just`'s own reflection. Bare `just` is explicitly bound to the `schema` recipe so the zero-argument entrypoint is deterministic and machine-readable. `just --list` remains the human-readable reflection surface and the bridge's raw source of recipe metadata.
 
 ### Discovery Flow
-1. **Reflection**: Agent runs `just --list`.
-2. **Scanning**: The agent (or Bridge) scans the output for lines starting with `    # @`.
-3. **Mapping**: These lines are mapped to the recipe immediately following them.
-4. **Registration**: The agent registers these as tools with the LLM, using `@usage` as the primary selection criteria.
+1. **Reflection**: Agent runs `just` (or `just schema`) to get the machine-readable manifest.
+2. **Listing**: When a human-readable recipe catalog is needed, agent runs `just --list`.
+3. **Scanning**: The bridge scans the `just --list` output for lines starting with `    # @`.
+4. **Mapping**: These lines are mapped to the recipe immediately following them.
+5. **Registration**: The agent registers these as tools with the LLM, using `@usage` as the primary selection criteria.
 
 ## 4. Technical Components
-- **API Bridge**: A utility that runs `just --list`, parses the `# @tag` metadata, and outputs a JSON schema (e.g., OpenAI Tool Specs).
+- **API Bridge**: A utility that runs `just --list`, parses the `# @tag` metadata, and emits the JSON returned by `just schema` (and therefore bare `just`).
 - **Execution Wrapper**: A thin layer that captures `stdout`, `stderr`, and exit codes, re-formatting them into "Agent-Friendly" responses.
 - **Protocol Recipes**: A set of standardized recipes (e.g., `list`, `schema`, `validate`) that define the agent's interaction with the workspace.
 


### PR DESCRIPTION
## Summary
- make `schema` the explicit `[default]` recipe in the agent-facing `Justfile`
- document bare `just` / `just schema` as the machine-readable discovery path
- keep `just --list` as the human-readable recipe catalog

## Verification
- `just schema`
- bare `just` matches `just schema`

Refs #153