### PR TITLE
Document single-recipe execution for agent-facing just invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 - Set the agent-facing `schema` recipe as the explicit `[default]` entrypoint so bare `just` deterministically returns the machine-readable discovery manifest without depending on recipe order, and documented `just --list` as the human-readable listing path.
 
+### Changed
+
+- Clarified the README, consumer docs, concept notes, and agent guidance to prefer `just schema` for agent discovery, reserve `just --list` for human-facing inspection, and require exactly one validated recipe per tool call with `just --one` as the guardrail when raw `just` execution remains exposed.
+
 ## [0.3.0] - 2026-04-30
 
 ### Changed

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,6 +5,7 @@
 
 ## Project Mandates
 - **Output is the API**: Use `just schema` as the primary machine-readable discovery surface. Use `just --list` for human-facing inspection, and avoid complex source parsing.
+- **One Recipe per Tool Call**: Agent-facing invocations should execute exactly one validated recipe; if direct `just` argv remains exposed, prefer `just --one` to fail closed on accidental multi-recipe calls.
 - **Use the Just LSP**: When working on Justfiles or recipes, prefer `just-lsp`/the Just LSP for navigation and refactors when it is available.
 - **Documentation is Data**: Use standard `[doc()]` attributes to communicate with agents.
 - **Zero Configuration**: A `Justfile` should be all that's needed to start.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -19,7 +19,7 @@ The documentation and local model support are solid. Next:
 
 ### 1. Reference Consumer (The "Just-Chat" Shell)
 Create a simple script or `just` recipe that demonstrates a Consumer Agent interaction.
-- **Logic**: NLP prompt -> `just schema` -> tool execution.
+- **Logic**: NLP prompt -> `just schema` -> single validated recipe execution.
 
 ### 2. Exporting the Skill
 Develop `just export-skill <format>` to package the `Justfile` for Gemini Skills or MCP.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ Release notes live in `CHANGELOG.md`, and git tags use the matching `vX.Y.Z` for
 
 To ensure interoperability, just-for-agents follows these conventions:
 
-* **The Discovery Pattern:** Agents should start with bare `just` (explicitly bound to `just schema`) or run `just schema` directly for machine-readable discovery. Use `just --list` when they need the human-readable recipe catalog instead of parsing the `Justfile` source directly.  
+* **The Discovery Pattern:** Agents should start with bare `just` (explicitly bound to `just schema`) or run `just schema` directly for machine-readable discovery. Use `just --list` when they need the human-readable recipe catalog instead of parsing the `Justfile` source directly.
+* **The Execution Pattern:** Agent-facing integrations must execute exactly one validated recipe per tool call. Do not rely on upstream multi-recipe argv such as `just a b c` as the default agent contract: agent-generated argv can ambiguously reinterpret or swallow later tokens as earlier recipe parameters.
+* **Guardrails Matter:** When direct `just` execution remains exposed, prefer `just --one <recipe> ...` so accidental multi-recipe invocations fail closed.
 * **The Argument Contract:** All variables in recipes should have sensible defaults or clear descriptions in the comments.  
 * **Safety First:** Destructive commands (e.g., rm, drop-db) must be explicitly tagged with @danger in the comments to trigger agent confirmation.
 

--- a/concept.md
+++ b/concept.md
@@ -42,6 +42,7 @@ Instead of parsing the `Justfile` source directly, the agent should prefer the e
 ## 4. Technical Components
 - **API Bridge**: A utility that runs `just --list`, parses the `# @tag` metadata, and emits the JSON returned by `just schema` (and therefore bare `just`) (e.g., OpenAI Tool Specs).
 - **Execution Wrapper**: A thin layer that captures `stdout`, `stderr`, and exit codes, re-formatting them into "Agent-Friendly" responses.
+- **Execution Contract**: Agent-facing executors must issue exactly one validated recipe per tool call. Upstream multi-recipe argv is useful CLI behavior, but unsafe as a default integration contract because later tokens can be reinterpreted or swallowed as earlier recipe parameters; where direct `just` execution remains exposed, prefer `just --one`.
 - **Protocol Recipes**: A set of standardized recipes (e.g., `list`, `schema`, `validate`) that define the agent's interaction with the workspace.
 
 ## 5. Open Questions

--- a/docs/annexes/consumer_agent.md
+++ b/docs/annexes/consumer_agent.md
@@ -176,7 +176,7 @@ The model should see a tiny toolset:
 | Tool | Purpose |
 | --- | --- |
 | `just_schema` | Return the cached manifest, optionally refreshing it |
-| `just_run` | Execute a validated `just` recipe with mapped arguments |
+| `just_run` | Execute exactly one validated `just` recipe with mapped arguments |
 | `just_escalate` | Invoke `just escalate "<prompt>"`, then auto-refresh the cached schema on success |
 | `just_refresh` | Re-run `bootstrap` and `schema` after direct `Justfile` changes |
 
@@ -185,11 +185,15 @@ The model should see a tiny toolset:
 
 1. Validate that the requested recipe exists in the cached schema
 2. Validate that only known parameters are passed
-3. Build argv in schema parameter order, passing recipe parameters positionally
-4. Execute without shell interpolation
-5. Return structured stdout/stderr/exit information
+3. Resolve the tool call to exactly one recipe invocation
+4. Build argv in schema parameter order, passing recipe parameters positionally
+5. Execute without shell interpolation
+6. Prefer `just --one <recipe> ...` as a guardrail when direct `just` execution remains exposed
+7. Return structured stdout/stderr/exit information
 
-This is important: because the Consumer Agent has no shell tool available, it cannot improvise shell commands even if it wanted to — it must call the documented API surface emitted by `just schema`. The tool call can still use named fields like `{ "file": "/path/to/file" }`, but the extension must translate those into positional `just` argv such as `just md5 /path/to/file`.
+This is important: because the Consumer Agent has no shell tool available, it cannot improvise shell commands even if it wanted to — it must call the documented API surface emitted by `just schema`. The tool call can still use named fields like `{ "file": "/path/to/file" }`, but the extension must translate those into one positional `just` invocation such as `just md5 /path/to/file`, not a multi-recipe argv.
+
+Upstream `just` supports multi-recipe argv like `just a b c`, but that is an unsafe default for agent-generated argv: later tokens can be interpreted as more recipe names or silently swallowed as parameters for the first recipe. Agent-facing integrations should therefore issue one validated recipe per tool call and use `--one` where a raw `just` shell-out path still exists.
 
 For the `research` recipe specifically, `rounds` should be treated as the number of **new** rounds to append in the current invocation. If the user asks for "1 iteration" or "one more round", the Consumer should call `research` with `rounds='1'` and let the recipe continue from the latest completed round automatically.
 

--- a/docs/personal_power_agent.md
+++ b/docs/personal_power_agent.md
@@ -127,8 +127,10 @@ Expected behavior:
 
 1. Pi uses the local Qwen Consumer model
 2. the extension restricts the model to `just_schema`, `just_run`, `just_refresh`, and `just_escalate`
-3. with shell, file-edit, and write tools removed from its toolset, the model maps your request onto `just` recipes — the Justfile is the entire capability surface it sees
+3. with shell, file-edit, and write tools removed from its toolset, the model maps your request onto exactly one validated `just` recipe per `just_run` call — the Justfile is the entire capability surface it sees
 4. if the current API is insufficient, it escalates through `just escalate`
+
+That single-recipe rule matters even though upstream `just` allows multi-recipe argv: agent-generated argv is a poor fit for `just a b c`, because later tokens can be misread as more recipe names or swallowed as parameters for the first one. If your consumer still shells out to `just` directly instead of using a stricter wrapper, prefer `just --one` so the invocation fails closed.
 
 When `just escalate` runs in a shell with `tmux` available, it creates or reuses the fixed tmux session `just-for-agents-escalate`, starts the Senior Agent in a prompt-derived window, and tells you how to attach. In iTerm2, it also attempts to open a tmux control-mode window automatically; later reattach with `tmux attach-session -t just-for-agents-escalate`.
 


### PR DESCRIPTION
## Summary
- document the one-recipe-per-tool-call contract for agent-facing just integrations
- explain why upstream multi-recipe argv is unsafe for agent-generated argv
- align discovery docs on `just schema` vs `just --list` and mention `just --one` as a guardrail

Closes #155