### PR TITLE
Fix Pi consumer target installs

### DIFF
--- a/.just-for-agents/bridge.py
+++ b/.just-for-agents/bridge.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import re
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -20,6 +21,10 @@ MANIFEST = {
         "Linux users: review https://github.com/terror/just-lsp before using install-lsp.",
     ],
 }
+
+
+def _split_tokens(text: str) -> list[str]:
+    return shlex.split(text, posix=True)
 
 
 def parse():
@@ -50,7 +55,7 @@ def parse():
             continue
         if not line or line.startswith("Available recipes"):
             continue
-        parts = line.split()
+        parts = _split_tokens(line)
         if not parts:
             continue
         recipe_name = parts[0]
@@ -70,7 +75,7 @@ def parse():
             recipe_part = line.strip()
         if not recipe_part:
             continue
-        parts = recipe_part.split()
+        parts = _split_tokens(recipe_part)
         name = parts[0]
         params = []
         for parameter in parts[1:]:
@@ -96,4 +101,5 @@ def parse():
     return {"manifest": MANIFEST, "tools": recipes}
 
 
-print(json.dumps(parse(), indent=2))
+if __name__ == "__main__":
+    print(json.dumps(parse(), indent=2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 ### Fixed
 
 - Set the agent-facing `schema` recipe as the explicit `[default]` entrypoint so bare `just` deterministically returns the machine-readable discovery manifest without depending on recipe order, and documented `just --list` as the human-readable listing path.
+- Fixed the Pi consumer installer and startup flow so `examples/pi-consumer/install.sh <target>` fully resets the target workspace's just-for-agents state, re-seeds the runtime bundle plus `.pi/` and `just_for_agents/`, and the consumer extension still enters just-only mode with an empty `just_schema` result if the target later loses its `Justfile`.
+- Fixed `.just-for-agents/bridge.py` to parse `just --list` recipe signatures with quoted defaults correctly, so schema entries like `content='hello world'` no longer turn into bogus required parameters during live Consumer runs.
 
 ### Changed
 

--- a/docs/agent_worktree_testing.md
+++ b/docs/agent_worktree_testing.md
@@ -28,15 +28,16 @@ If any are missing, stop and report — do not attempt to install host-level dep
 ## 2. Run the installer
 
 ```bash
-bash examples/pi-consumer/install.sh
+bash examples/pi-consumer/install.sh "$PWD"
 ```
 
 Expected outcomes:
 
 - `~/.pi/agent/models.json` is updated (a `.bak` is written if it already existed); the Ollama provider entry is merged, not overwritten.
 - `just-consumer-qwen3.6:latest` is rebuilt from the worktree's `examples/pi-consumer/Modelfile`.
-- `.pi/settings.json`, `.pi/extensions/just-consumer.ts`, `.pi/extensions/package.json`, and `.pi/consumer-profile.json` are written into the worktree root.
-- `npm install --prefix .pi/extensions` resolves `typebox`.
+- `Justfile`, `.just-for-agents/`, `just_for_agents/`, `VERSION`, `README.md`, and `CHANGELOG.md` in the selected target are reset from the worktree checkout.
+- `.pi/settings.json`, `.pi/extensions/just-consumer.ts`, `.pi/extensions/package.json`, and `.pi/consumer-profile.json` are written into the selected target directory (`"$PWD"` in this procedure, i.e. the worktree root).
+- `npm install --prefix "$PWD/.pi/extensions"` resolves `typebox`.
 
 ## 3. Smoke tests
 
@@ -88,7 +89,7 @@ grep -n "Your only tools are\|toolset\|capability surface" examples/pi-consumer/
 
 ## 4. Cleanup before commit / PR
 
-The smoke tests intentionally mutate the worktree (escalation rewrites `Justfile` and `CHANGELOG.md`, and writes `test.txt` plus a `.pi/` directory). None of that should land in the PR.
+The smoke tests intentionally mutate the worktree (escalation rewrites `Justfile` and `CHANGELOG.md` and writes `test.txt`, while the installer writes a `.pi/` directory into the chosen target). None of that should land in the PR.
 
 ```bash
 # Drop test artifacts that the Senior Agent or test commands created.

--- a/docs/annexes/consumer_agent.md
+++ b/docs/annexes/consumer_agent.md
@@ -34,11 +34,11 @@ This repo now includes a concrete reference bundle under `examples/pi-consumer/`
 
 To use the bundle as-is:
 
-1. copy `models.json` into `~/.pi/agent/models.json` (or merge it)
-2. copy `settings.json` into your project's `.pi/settings.json`
-3. copy `just-consumer.ts` into `.pi/extensions/just-consumer.ts`
-4. copy `package.json` into `.pi/extensions/package.json` and run `npm install` there so Pi can resolve `typebox`
-5. optionally copy `profile.json` into `.pi/consumer-profile.json` for branding and personalization
+```bash
+bash examples/pi-consumer/install.sh /path/to/target-project
+```
+
+That merges `models.json` into `~/.pi/agent/models.json`, resets the target's JFA-managed paths, installs the runtime bundle (`Justfile`, `.just-for-agents/`, `just_for_agents/`, `VERSION`, `README.md`, `CHANGELOG.md`), installs the project-local Pi bundle into `/path/to/target-project/.pi/`, and runs `npm install` inside the target's `.pi/extensions/` directory. If you prefer to do it manually, copy both the runtime files and the Pi-local files into the matching target paths yourself.
 
 ## 🧱 Reference Implementation
 
@@ -164,6 +164,8 @@ On `before_agent_start`, the extension should inject:
 - optional personality-affinity instructions derived from the profile
 
 The primary mechanism for the toolset restriction is `pi.setActiveTools(CONSUMER_TOOLS)` on `session_start`, which removes `bash`, `edit`, `write`, and any other non-Consumer tools from the model's available tool list. As defense-in-depth, the extension also installs a `tool_call` hook that blocks `bash`, `edit`, and `write` if Consumer mode is active — but the model should never see those tool names in the first place.
+
+Consumer mode should still activate even when the target workspace does not contain a `Justfile` yet. In that case, startup branding still appears, only the `just_*` tools are exposed, and `just_schema` returns an empty manifest instead of throwing a hard error. The target installer normally seeds a `Justfile`, so this fallback mainly covers manual damage or partially reset targets.
 
 On `turn_start` or `session_start`, the extension should persist its cached state with `pi.appendEntry()` so resumed sessions restore the manifest and mode cleanly.
 

--- a/docs/personal_power_agent.md
+++ b/docs/personal_power_agent.md
@@ -80,39 +80,43 @@ If you already use Pi and already have `~/.pi/agent/models.json`, merge the Olla
 
 ### 4. Install the project-local Consumer extension
 
-From the root of this repo:
+From the `just-for-agents` development checkout, install into the target workspace:
 
 ```bash
-mkdir -p .pi/extensions
-cp examples/pi-consumer/settings.json .pi/settings.json
-cp examples/pi-consumer/just-consumer.ts .pi/extensions/just-consumer.ts
-cp examples/pi-consumer/package.json .pi/extensions/package.json
-cp examples/pi-consumer/profile.json .pi/consumer-profile.json
-npm install --prefix .pi/extensions
+bash examples/pi-consumer/install.sh /path/to/target-workspace
 ```
 
-This gives the project the exact Pi setup described in Annex A:
+The installer still merges the Ollama provider into `~/.pi/agent/models.json`, but it now treats the selected target root as a **fresh just-for-agents install**: it resets the target's JFA-managed paths (`.pi/`, `.just-for-agents/`, `just_for_agents/`, `Justfile`, `VERSION`, `README.md`, and `CHANGELOG.md`) and then re-seeds them from the development checkout. If you omit the target, it falls back to the current repo root for backward compatibility.
 
+This gives the target workspace the exact just-for-agents runtime plus the Pi setup described in Annex A:
+
+- root `Justfile`
+- `.just-for-agents/` runtime helpers
+- `just_for_agents/` Python package for the managed governance commands
+- `VERSION`, `README.md`, and `CHANGELOG.md`
 - default provider: `ollama`
 - default model: `just-consumer-qwen3.6:latest`
 - default thinking: `off`
 - project-local Pi extension: `just-consumer.ts`
 - optional personalization hook: `.pi/consumer-profile.json`
 
-### 5. Start Pi in this repo
+### 5. Start Pi in the target workspace
 
 ```bash
+cd /path/to/target-workspace
 pi
 ```
 
 On startup, the Consumer extension will:
 
-1. detect the local `Justfile`
+1. detect the freshly installed local `Justfile`
 2. run `just bootstrap`
 3. run `just schema`
 4. load `.pi/consumer-profile.json` if present
 5. cache the manifest
 6. switch Pi into Consumer mode
+
+If you deliberately remove the target `Justfile` later, Consumer mode still activates and only the `just_*` tools are exposed. In that case `just_schema` returns an empty manifest until the workspace is repopulated with a Justfile-based tool surface.
 7. show branded startup guidance in the Pi UI without sending it into model context when possible
 
 ### 6. Use the Consumer Agent the intended way

--- a/docs/pi_consumer_target_install_protocol.md
+++ b/docs/pi_consumer_target_install_protocol.md
@@ -1,0 +1,209 @@
+# Pi consumer target-install test protocol
+
+## Goal
+
+Validate that `examples/pi-consumer/install.sh <target>` can reset a scratch workspace into a runnable just-for-agents install, then launch Pi in that target and behave like the Consumer flow described in `docs/personal_power_agent.md`.
+
+Target workspace used for live testing:
+
+```bash
+/Users/earchibald/scratch/014-jfa-testing
+```
+
+## Reset/install command
+
+Run from the development checkout:
+
+```bash
+bash examples/pi-consumer/install.sh /Users/earchibald/scratch/014-jfa-testing
+```
+
+Expected reset semantics:
+
+- remove prior just-for-agents state from the target: `.pi/`, `.just-for-agents/`, `just_for_agents/`, `Justfile`, `VERSION`, `README.md`, `CHANGELOG.md`
+- re-seed the runtime bundle from the development checkout
+- rebuild/refresh the Pi-local `.pi/` bundle in the target
+- keep the Ollama model registration flow in `~/.pi/agent/models.json`
+
+## Iteration log
+
+### Iteration 1 — reproduce the broken target install
+
+Command:
+
+```bash
+~/.config/superpowers/worktrees/just-for-agents/jfa-87-target-install-script/examples/pi-consumer/install.sh /Users/earchibald/scratch/014-jfa-testing
+```
+
+Observed result:
+
+- only `.pi/` was installed into the target
+- the target still had no `Justfile`
+- `pi` in the target fell back to the default tool surface because the consumer extension had nothing to bootstrap
+
+Conclusion:
+
+- target-install support alone was not enough
+- the installer must provision a runnable just-for-agents runtime, not only the Pi overlay
+
+### Iteration 2 — install runtime bundle and verify startup
+
+After redesigning the installer, the target now contains:
+
+- `.just-for-agents/`
+- `just_for_agents/`
+- `Justfile`
+- `VERSION`
+- `README.md`
+- `CHANGELOG.md`
+- `.pi/`
+
+Quick verification:
+
+```bash
+cd /Users/earchibald/scratch/014-jfa-testing
+just schema | head
+```
+
+Observed result:
+
+- `just schema` returns the expected just-for-agents manifest from the scratch workspace
+
+### Iteration 3 — tmux Pi smoke test
+
+Launch:
+
+```bash
+tmux new-session -d -s jfa87-pi-smoke -n consumer 'cd /Users/earchibald/scratch/014-jfa-testing && pi'
+```
+
+#### Check 1 — startup branding
+
+Observed result:
+
+- startup banner renders in tmux
+- branding matches the Consumer profile
+- the prompt text says the only tools are `just_schema`, `just_run`, `just_refresh`, and `just_escalate`
+
+#### Check 2 — tool-surface restriction
+
+Prompt sent via tmux:
+
+```text
+Before doing anything else, list the exact tool names available to you right now and nothing else.
+```
+
+Observed result:
+
+```text
+just_schema, just_run, just_escalate, just_refresh
+```
+
+Conclusion:
+
+- the live Pi session is now using the just-only Consumer tool surface
+
+#### Check 3 — `just_run` smoke
+
+Prompt:
+
+```text
+Calculate the MD5 hash of the README.md file.
+```
+
+Expected hash:
+
+```text
+6448adce52a1bdd9141771b5822041c3
+```
+
+Observed result:
+
+- Pi chose `just_run`
+- the returned hash matched the shell-computed hash exactly
+
+#### Check 4 — first `just_escalate` smoke
+
+Prompt:
+
+```text
+Create a file called test.txt with the text 'hello'.
+```
+
+Observed result:
+
+- Pi correctly chose `just_escalate`
+- the visible-agent tmux session `just-for-agents-escalate` launched from the scratch install
+- the first attempt exposed another missing runtime dependency: the target workspace also needed the in-tree `just_for_agents/` Python package, not only `.just-for-agents/`
+
+Conclusion:
+
+- the installer bundle had to grow beyond the Justfile wrappers
+
+### Iteration 4 — add `just_for_agents/` to the target install
+
+Installer refinement:
+
+- reset and copy `just_for_agents/` alongside `.just-for-agents/`, `Justfile`, `VERSION`, `README.md`, `CHANGELOG.md`, and `.pi/`
+
+Observed result:
+
+- the escalation tmux session now progressed through managed request creation and dry-run/approval work instead of failing immediately on a missing module
+
+### Iteration 5 — fix schema parsing for quoted defaults
+
+Live failure uncovered after the request was approved:
+
+- the Consumer refreshed schema after the new recipe appeared
+- the bridge parsed a signature like `content='hello world'` with a naive whitespace split
+- the Consumer then saw a bogus required parameter name (`world'`) and could not call the new recipe
+
+Fix applied:
+
+- `.just-for-agents/bridge.py` now uses shell-aware tokenization for `just --list` output instead of `split()`
+
+### Iteration 6 — fresh end-to-end rerun after installer + bridge fixes
+
+Fresh reset:
+
+```bash
+bash examples/pi-consumer/install.sh /Users/earchibald/scratch/014-jfa-testing
+```
+
+Fresh tmux run:
+
+```bash
+tmux new-session -d -s jfa87-pi-smoke -n consumer 'cd /Users/earchibald/scratch/014-jfa-testing && pi'
+```
+
+Observed result:
+
+- startup branding still passed
+- tool-surface restriction still passed
+- `just_run` (`md5 README.md`) still passed
+- `just_escalate` still launched correctly and staged a new quarantined request
+- the remaining blocker moved deeper again: the latest request (`file-write`) is still failing during the managed dry-run stage before the user-level `test.txt` action completes
+
+Current blocker snapshot:
+
+- request: `req-20260502-001`
+- target recipe: `file-write`
+- current request status: `quarantined`
+- current dry-run summary: `dry-run failed for file-write (exit 1)`
+
+## Current status
+
+### Passing
+
+- target install resets and reseeds the scratch workspace
+- Pi startup branding appears in tmux
+- only the four `just_*` consumer tools are exposed
+- `just_schema` works from the target install
+- `just_run` works from the target install
+- `just_escalate` launches the expected visible-agent tmux session from the target install
+- schema refresh now handles quoted defaults with spaces correctly
+
+### Still open
+
+- complete the end-to-end escalation smoke so the scratch install can successfully add a new capability and create `test.txt`
+- document/fix the managed dry-run failure uncovered by the latest live escalation session

--- a/examples/pi-consumer/install.sh
+++ b/examples/pi-consumer/install.sh
@@ -5,12 +5,22 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 EXAMPLE_DIR="$SCRIPT_DIR"
 REPO_ROOT="$(cd -- "$EXAMPLE_DIR/../.." && pwd)"
 PI_AGENT_DIR="$HOME/.pi/agent"
-PROJECT_PI_DIR="$REPO_ROOT/.pi"
-EXT_DIR="$PROJECT_PI_DIR/extensions"
 MODELS_TARGET="$PI_AGENT_DIR/models.json"
 MODELS_SOURCE="$EXAMPLE_DIR/models.json"
 CONSUMER_MODEL_ID="just-consumer-qwen3.6:latest"
 RESEARCH_MODEL_ID="just-research-qwen3.6:latest"
+
+usage() {
+  cat <<'EOF'
+Usage: bash examples/pi-consumer/install.sh [--target <dir> | <dir>]
+
+Build the local Pi consumer bundle from this just-for-agents checkout and reset
+the selected target root to a fresh just-for-agents runtime install.
+
+If no target is provided, the installer keeps the existing behavior and writes into
+this checkout's root.
+EOF
+}
 
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -19,11 +29,84 @@ require_cmd() {
   }
 }
 
+resolve_target_root() {
+  local target_input="$1"
+
+  if [ -e "$target_input" ] && [ ! -d "$target_input" ]; then
+    echo "ERROR: target exists but is not a directory: $target_input" >&2
+    exit 1
+  fi
+
+  mkdir -p "$target_input"
+  (
+    cd -- "$target_input"
+    pwd
+  )
+}
+
+reset_target_jfa_state() {
+  local target_root="$1"
+
+  rm -rf \
+    "$target_root/.pi" \
+    "$target_root/.just-for-agents" \
+    "$target_root/just_for_agents" \
+    "$target_root/Justfile" \
+    "$target_root/VERSION" \
+    "$target_root/README.md" \
+    "$target_root/CHANGELOG.md"
+}
+
+install_runtime_bundle() {
+  local target_root="$1"
+
+  cp "$REPO_ROOT/Justfile" "$target_root/Justfile"
+  cp "$REPO_ROOT/VERSION" "$target_root/VERSION"
+  cp "$REPO_ROOT/README.md" "$target_root/README.md"
+  cp "$REPO_ROOT/CHANGELOG.md" "$target_root/CHANGELOG.md"
+  cp -R "$REPO_ROOT/.just-for-agents" "$target_root/.just-for-agents"
+  cp -R "$REPO_ROOT/just_for_agents" "$target_root/just_for_agents"
+}
+
+TARGET_ROOT="$REPO_ROOT"
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --target)
+      if [ "$#" -ne 2 ]; then
+        echo "ERROR: --target expects exactly one directory argument" >&2
+        usage >&2
+        exit 1
+      fi
+      TARGET_ROOT="$(resolve_target_root "$2")"
+      ;;
+    *)
+      if [ "$#" -ne 1 ]; then
+        echo "ERROR: expected zero arguments, a single target directory, or --target <dir>" >&2
+        usage >&2
+        exit 1
+      fi
+      TARGET_ROOT="$(resolve_target_root "$1")"
+      ;;
+  esac
+fi
+
+PROJECT_PI_DIR="$TARGET_ROOT/.pi"
+EXT_DIR="$PROJECT_PI_DIR/extensions"
+
 require_cmd python3
 require_cmd npm
 require_cmd ollama
 
+echo "==> Resetting just-for-agents state in $TARGET_ROOT"
+reset_target_jfa_state "$TARGET_ROOT"
 mkdir -p "$PI_AGENT_DIR" "$EXT_DIR"
+
+echo "==> Installing just-for-agents runtime bundle into $TARGET_ROOT"
+install_runtime_bundle "$TARGET_ROOT"
 
 echo "==> Building Ollama model: $CONSUMER_MODEL_ID"
 ollama create "$CONSUMER_MODEL_ID" -f "$EXAMPLE_DIR/Modelfile"
@@ -78,7 +161,7 @@ with open(target_path, "w", encoding="utf-8") as f:
     f.write("\n")
 PY
 
-echo "==> Installing project-local Pi consumer files"
+echo "==> Installing project-local Pi consumer files into $TARGET_ROOT"
 cp "$EXAMPLE_DIR/settings.json" "$PROJECT_PI_DIR/settings.json"
 cp "$EXAMPLE_DIR/just-consumer.ts" "$EXT_DIR/just-consumer.ts"
 cp "$EXAMPLE_DIR/package.json" "$EXT_DIR/package.json"
@@ -88,5 +171,5 @@ echo "==> Installing extension dependencies"
 npm install --prefix "$EXT_DIR"
 
 echo
-echo "Done. Start Pi in this repo with:"
-echo "  pi"
+echo "Done. Start Pi in the target workspace with:"
+echo "  cd \"$TARGET_ROOT\" && pi"

--- a/examples/pi-consumer/just-consumer.ts
+++ b/examples/pi-consumer/just-consumer.ts
@@ -49,12 +49,29 @@ type ConsumerProfile = {
 
 const CONSUMER_TOOLS = ["just_schema", "just_run", "just_escalate", "just_refresh"];
 const BLOCKED_TOOLS = new Set(["bash", "edit", "write"]);
+const JUSTFILE_CANDIDATES = ["Justfile", "justfile"];
 
 function runJust(cwd: string, args: string[]) {
 	return spawnSync("just", args, {
 		cwd,
 		encoding: "utf8",
 	});
+}
+
+function workspaceHasJustfile(cwd: string) {
+	return JUSTFILE_CANDIDATES.some((name) => existsSync(join(cwd, name)));
+}
+
+function emptyManifest(): Manifest {
+	return {
+		manifest: {
+			principle: "RADICALLY SIMPLE",
+			rules_of_engagement: [
+				"No Justfile was found in this workspace yet. Consumer mode stays active, but just_schema is empty until a Justfile is added.",
+			],
+		},
+		tools: [],
+	};
 }
 
 function hasOwn(object: Record<string, string>, key: string) {
@@ -171,6 +188,10 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 	}
 
 	function refreshManifest(cwd: string): Manifest {
+		if (!workspaceHasJustfile(cwd)) {
+			manifest = emptyManifest();
+			return manifest;
+		}
 		requireSuccess(runJust(cwd, ["bootstrap"]), "just bootstrap");
 		const schemaOutput = requireSuccess(runJust(cwd, ["schema"]), "just schema");
 		const parsed = JSON.parse(schemaOutput) as Manifest;
@@ -255,6 +276,7 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 			return {
 				content: [{ type: "text", text: JSON.stringify(currentManifest, null, 2) }],
 				details: {
+					hasJustfile: workspaceHasJustfile(ctx.cwd),
 					toolCount: (currentManifest.tools ?? []).length,
 				},
 			};
@@ -268,10 +290,15 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 		parameters: Type.Object({}),
 		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
 			const currentManifest = refreshManifest(ctx.cwd);
+			const hasJustfile = workspaceHasJustfile(ctx.cwd);
+			const message = hasJustfile
+				? "Refreshed bootstrap instructions and schema."
+				: "No Justfile found. Consumer mode is active, and the cached schema remains empty until this workspace gets a Justfile.";
 			persistState();
 			return {
-				content: [{ type: "text", text: `Refreshed bootstrap instructions and schema.` }],
+				content: [{ type: "text", text: message }],
 				details: {
+					hasJustfile,
 					toolCount: (currentManifest.tools ?? []).length,
 				},
 			};
@@ -292,6 +319,11 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const currentManifest = ensureManifest(ctx);
+			if (!workspaceHasJustfile(ctx.cwd)) {
+				throw new Error(
+					"No Justfile found in this workspace, so there are no recipes to run yet.",
+				);
+			}
 			const tool = findTool(params.recipe, currentManifest);
 			const args = params.args ?? {};
 			if (!tool) {
@@ -322,6 +354,11 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 			prompt: Type.String({ description: "Describe the missing capability" }),
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			if (!workspaceHasJustfile(ctx.cwd)) {
+				throw new Error(
+					"No Justfile found in this workspace, so just_escalate cannot add or refresh recipes yet.",
+				);
+			}
 			const result = runJust(ctx.cwd, ["escalate", params.prompt]);
 			requireSuccess(result, "just escalate");
 			const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
@@ -339,7 +376,6 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
-		if (!existsSync(join(ctx.cwd, "Justfile"))) return;
 		try {
 			profile = loadProfile(ctx.cwd);
 		} catch (error) {
@@ -364,6 +400,12 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 
 		setConsumerMode(ctx, true);
 		showStartupBranding(ctx);
+		if (!workspaceHasJustfile(ctx.cwd)) {
+			ctx.ui.notify(
+				"No Justfile found in this workspace yet. Consumer mode is active with only just_* tools, and just_schema will stay empty until a Justfile is added.",
+				"info",
+			);
+		}
 		persistState();
 	});
 
@@ -396,6 +438,7 @@ Consumer mode rules:
 - Your only tools are just_schema, just_run, just_refresh, and just_escalate. No shell, file-edit, or write tools are available; the Justfile is the entire capability surface.
 - Never parse the Justfile source directly — call just_schema instead.
 - Treat just schema as the authoritative API surface.
+- If just_schema returns no recipes, explain that the workspace has no Justfile yet and do not invent tools.
 - Pass just_run arguments by schema parameter name, but remember the extension executes just recipe parameters positionally.
 - For example, for md5(file), call just_run with args like {"file": "/path/to/file"} and let the extension run \`just md5 /path/to/file\`.
 - When keyed args skip an optional parameter that has a schema default, the extension fills that default automatically before executing the positional just recipe.

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,45 @@
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BRIDGE_PATH = REPO_ROOT / ".just-for-agents" / "bridge.py"
+
+
+def _load_bridge_module():
+    spec = importlib.util.spec_from_file_location("jfa_bridge", BRIDGE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class BridgeParseTests(unittest.TestCase):
+    def test_parse_preserves_quoted_default_with_spaces(self) -> None:
+        bridge = _load_bridge_module()
+        list_output = """Available recipes:\ncreate-text-file path='test.txt' content='hello world'\n"""
+
+        with patch.object(
+            bridge.subprocess,
+            "check_output",
+            return_value=list_output.encode("utf-8"),
+        ):
+            payload = bridge.parse()
+
+        tool = payload["tools"][0]
+        self.assertEqual(tool["name"], "create-text-file")
+        self.assertEqual(
+            tool["parameters"],
+            [
+                {"name": "path", "required": False, "default": "test.txt"},
+                {"name": "content", "required": False, "default": "hello world"},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pi_consumer_extension.py
+++ b/tests/test_pi_consumer_extension.py
@@ -1,0 +1,19 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONSUMER_EXTENSION = REPO_ROOT / "examples" / "pi-consumer" / "just-consumer.ts"
+
+
+class PiConsumerExtensionSourceTests(unittest.TestCase):
+    def test_consumer_mode_no_longer_requires_justfile_at_startup(self) -> None:
+        source = CONSUMER_EXTENSION.read_text(encoding="utf-8")
+        self.assertNotIn('if (!existsSync(join(ctx.cwd, "Justfile"))) return;', source)
+        self.assertIn("function workspaceHasJustfile(", source)
+        self.assertIn("No Justfile found in this workspace yet.", source)
+        self.assertIn("pi.setActiveTools(CONSUMER_TOOLS);", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pi_consumer_install.py
+++ b/tests/test_pi_consumer_install.py
@@ -1,0 +1,76 @@
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SCRIPT = REPO_ROOT / "examples" / "pi-consumer" / "install.sh"
+
+
+def _write_stub(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class PiConsumerInstallScriptTests(unittest.TestCase):
+    def test_resets_and_reinstalls_runtime_and_pi_bundle_into_selected_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            fake_bin = root / "bin"
+            target = root / "target-workspace"
+            home.joinpath(".pi", "agent").mkdir(parents=True, exist_ok=True)
+            fake_bin.mkdir()
+            target.mkdir()
+            (target / ".pi").mkdir()
+            (target / ".pi" / "stale.txt").write_text("old pi state\n", encoding="utf-8")
+            (target / ".just-for-agents").mkdir()
+            (target / ".just-for-agents" / "stale.txt").write_text("old runtime state\n", encoding="utf-8")
+            (target / "just_for_agents").mkdir()
+            (target / "just_for_agents" / "stale.txt").write_text("old python package state\n", encoding="utf-8")
+            (target / "Justfile").write_text("stale\n", encoding="utf-8")
+
+            _write_stub(
+                fake_bin / "ollama",
+                "#!/usr/bin/env bash\nexit 0\n",
+            )
+            _write_stub(
+                fake_bin / "npm",
+                "#!/usr/bin/env bash\nexit 0\n",
+            )
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+            subprocess.run(
+                ["bash", str(INSTALL_SCRIPT), str(target)],
+                check=True,
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertTrue((target / "Justfile").is_file())
+            self.assertTrue((target / ".just-for-agents").is_dir())
+            self.assertTrue((target / "just_for_agents").is_dir())
+            self.assertTrue((target / "VERSION").is_file())
+            self.assertTrue((target / "README.md").is_file())
+            self.assertTrue((target / "CHANGELOG.md").is_file())
+            self.assertTrue((target / ".pi" / "settings.json").is_file())
+            self.assertTrue((target / ".pi" / "extensions" / "just-consumer.ts").is_file())
+            self.assertTrue((target / ".pi" / "extensions" / "package.json").is_file())
+            self.assertTrue((target / ".pi" / "consumer-profile.json").is_file())
+            self.assertTrue((home / ".pi" / "agent" / "models.json").is_file())
+            self.assertFalse((target / ".pi" / "stale.txt").exists())
+            self.assertFalse((target / ".just-for-agents" / "stale.txt").exists())
+            self.assertFalse((target / "just_for_agents" / "stale.txt").exists())
+            self.assertNotEqual((target / "Justfile").read_text(encoding="utf-8"), "stale\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make examples/pi-consumer/install.sh reset and re-seed a runnable just-for-agents target workspace
- keep the Pi consumer in just-only mode and fix bridge parsing for quoted defaults with spaces
- add installer/bridge regression tests and a live tmux smoke protocol doc

## Testing
- python3 -m unittest discover -s tests -p 'test_*.py' -v\n- just schema\n- bash examples/pi-consumer/install.sh /Users/earchibald/scratch/014-jfa-testing\n- live tmux smoke in /Users/earchibald/scratch/014-jfa-testing (startup, tool surface, md5)\n\n## Follow-up\n- The final end-to-end just_escalate smoke still stops at a managed dry-run failure for req-20260502-001 / file-write in the scratch workspace; see docs/pi_consumer_target_install_protocol.md.