### PR TITLE
Document Justfile root cwd contract

### DIFF
--- a/.just-for-agents/protocol.just
+++ b/.just-for-agents/protocol.just
@@ -11,8 +11,10 @@
     echo "4. Always prefix agent-facing documentation with '@tag' inside [doc('')]."
     echo "5. Agents supporting LSPs should run 'just install-lsp' and use 'just-lsp' for Justfile navigation and refactors."
     echo "6. If you touched managed recipes, run 'just managed-dashboard' and 'just schema'; direct edits under approved/ are treated as drift."
-    echo "7. Update CHANGELOG.md before stopping if you changed the repository."
-    echo "8. You are now authorized to manage this Justfile as your primary toolset."
+    echo "7. Agent-facing helper justfiles intentionally use '[no-cd]' so recipe bodies keep the caller repo/worktree root instead of running from '.just-for-agents/'."
+    echo "8. Start agent-facing 'just' commands at the repo/worktree root, or pass '--justfile /path/to/Justfile' when launching from elsewhere."
+    echo "9. Update CHANGELOG.md before stopping if you changed the repository."
+    echo "10. You are now authorized to manage this Justfile as your primary toolset."
 
 [no-cd]
 @version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 ### Changed
 
 - Clarified the README, consumer docs, concept notes, and agent guidance to prefer `just schema` for agent discovery, reserve `just --list` for human-facing inspection, and require exactly one validated recipe per tool call with `just --one` as the guardrail when raw `just` execution remains exposed.
+- Documented the root-cwd contract for agent-facing `just` invocations, including why helper justfiles use `[no-cd]` and when callers should pass `--justfile` from outside the repo or worktree root.
 
 ## [0.3.0] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ pip install just-for-agents
 \# Instruct an agent to learn the local environment  
 just-for-agents \--summarize
 
+### **Invocation Contract**
+
+The root `Justfile` is the public entrypoint for agent-facing recipes such as `just schema`, `just bootstrap`, and `just escalate`. Those recipes delegate into `.just-for-agents/*.just`, and the helper justfiles intentionally use `[no-cd]` so their bodies keep running from the caller repo or worktree root instead of from `.just-for-agents/`. That keeps relative paths like `Justfile`, `VERSION`, `CHANGELOG.md`, `docs/`, and `.just-for-agents/` anchored to the active checkout.
+
+The caller contract follows from that design: start agent-facing `just` invocations at the repo or git-worktree root. If you need to launch from elsewhere, point `just` at the root entrypoint explicitly, for example `just --justfile /path/to/repo/Justfile schema`.
+
 ### **Operational Helpers**
 
 For tmux-backed research runs, use the built-in runtime helpers instead of ad-hoc shell inspection:

--- a/docs/agent_worktree_testing.md
+++ b/docs/agent_worktree_testing.md
@@ -8,6 +8,8 @@ The procedure is non-interactive end-to-end so it can be driven by another agent
 
 You are working inside the worktree directory. All commands assume the worktree root is the current working directory. Do not run any of this from the main checkout.
 
+The root `Justfile` is the public entrypoint for agent-facing recipes. It delegates into `.just-for-agents/*.just`, and those helper justfiles intentionally use `[no-cd]` so the recipe bodies keep operating from the current worktree root instead of from `.just-for-agents/`. If you need to launch from elsewhere, use `just --justfile /path/to/worktree/Justfile <recipe>` so the invocation still binds to the intended checkout.
+
 Required on the host:
 
 - `pi` (`@mariozechner/pi-coding-agent`)


### PR DESCRIPTION
## Summary
- document why agent-facing helper justfiles use `[no-cd]` and keep execution rooted at the caller checkout
- document the caller contract to run from the repo/worktree root or pass `--justfile` explicitly
- record the docs-only clarification in the changelog

Closes #161