### PR TITLE
Enforce single-recipe execution in agent-facing integrations

### DIFF
--- a/.just-for-agents/research.just
+++ b/.just-for-agents/research.just
@@ -33,7 +33,7 @@ _research-schema-summary:
 
     schema = json.loads(
         subprocess.run(
-            ["just", "schema"],
+            ["just", "--one", "schema"],
             check=True,
             capture_output=True,
             text=True,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 - Set the agent-facing `schema` recipe as the explicit `[default]` entrypoint so bare `just` deterministically returns the machine-readable discovery manifest without depending on recipe order, and documented `just --list` as the human-readable listing path.
 - Fixed the Pi consumer installer and startup flow so `examples/pi-consumer/install.sh <target>` fully resets the target workspace's just-for-agents state, re-seeds the runtime bundle plus `.pi/` and `just_for_agents/`, and the consumer extension still enters just-only mode with an empty `just_schema` result if the target later loses its `Justfile`.
 - Fixed `.just-for-agents/bridge.py` to parse `just --list` recipe signatures with quoted defaults correctly, so schema entries like `content='hello world'` no longer turn into bogus required parameters during live Consumer runs.
+- Fixed agent-facing direct `just` integrations to fail closed on multi-recipe execution: managed request payloads now require exactly one target recipe, managed dry-runs shell out with `just --one`, and the Pi consumer example now wraps bootstrap/schema/run/escalate calls with the same single-recipe guardrail.
 
 ### Changed
 

--- a/docs/annexes/consumer_agent.md
+++ b/docs/annexes/consumer_agent.md
@@ -193,7 +193,7 @@ The model should see a tiny toolset:
 6. Prefer `just --one <recipe> ...` as a guardrail when direct `just` execution remains exposed
 7. Return structured stdout/stderr/exit information
 
-This is important: because the Consumer Agent has no shell tool available, it cannot improvise shell commands even if it wanted to — it must call the documented API surface emitted by `just schema`. The tool call can still use named fields like `{ "file": "/path/to/file" }`, but the extension must translate those into one positional `just` invocation such as `just md5 /path/to/file`, not a multi-recipe argv.
+This is important: because the Consumer Agent has no shell tool available, it cannot improvise shell commands even if it wanted to — it must call the documented API surface emitted by `just schema`. The tool call can still use named fields like `{ "file": "/path/to/file" }`, but the extension must translate those into one positional `just` invocation such as `just --one md5 /path/to/file`, not a multi-recipe argv.
 
 Upstream `just` supports multi-recipe argv like `just a b c`, but that is an unsafe default for agent-generated argv: later tokens can be interpreted as more recipe names or silently swallowed as parameters for the first recipe. Agent-facing integrations should therefore issue one validated recipe per tool call and use `--one` where a raw `just` shell-out path still exists.
 
@@ -216,10 +216,10 @@ export default function (pi: ExtensionAPI) {
   let consumerMode = false;
 
   function refreshManifest(cwd: string) {
-    const bootstrap = spawnSync("just", ["bootstrap"], { cwd, encoding: "utf8" });
+    const bootstrap = spawnSync("just", ["--one", "bootstrap"], { cwd, encoding: "utf8" });
     if (bootstrap.status !== 0) throw new Error(bootstrap.stderr || "just bootstrap failed");
 
-    const schema = spawnSync("just", ["schema"], { cwd, encoding: "utf8" });
+    const schema = spawnSync("just", ["--one", "schema"], { cwd, encoding: "utf8" });
     if (schema.status !== 0) throw new Error(schema.stderr || "just schema failed");
 
     manifest = JSON.parse(schema.stdout);
@@ -257,7 +257,7 @@ export default function (pi: ExtensionAPI) {
       if (!manifest) refreshManifest(ctx.cwd);
       const result = spawnSync(
         "just",
-        [params.recipe, ...Object.entries(params.args || {}).map(([k, v]) => `${k}=${v}`)],
+        ["--one", params.recipe, ...Object.entries(params.args || {}).map(([k, v]) => `${k}=${v}`)],
         { cwd: ctx.cwd, encoding: "utf8" }
       );
 
@@ -281,7 +281,7 @@ export default function (pi: ExtensionAPI) {
       prompt: Type.String()
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = spawnSync("just", ["escalate", params.prompt], { cwd: ctx.cwd, encoding: "utf8" });
+      const result = spawnSync("just", ["--one", "escalate", params.prompt], { cwd: ctx.cwd, encoding: "utf8" });
       if (result.status !== 0) {
         throw new Error([result.stdout, result.stderr].filter(Boolean).join("\n").trim());
       }

--- a/examples/pi-consumer/just-consumer.ts
+++ b/examples/pi-consumer/just-consumer.ts
@@ -74,6 +74,21 @@ function emptyManifest(): Manifest {
 	};
 }
 
+function validateRecipeName(recipe: string) {
+	const normalized = recipe.trim();
+	if (!normalized) {
+		throw new Error("Recipe name cannot be empty.");
+	}
+	if (/\s/.test(normalized)) {
+		throw new Error(`Recipe name must be exactly one token, got ${JSON.stringify(recipe)}`);
+	}
+	return normalized;
+}
+
+function runJustRecipe(cwd: string, recipe: string, args: string[] = []) {
+	return runJust(cwd, ["--one", validateRecipeName(recipe), ...args]);
+}
+
 function hasOwn(object: Record<string, string>, key: string) {
 	return Object.prototype.hasOwnProperty.call(object, key);
 }
@@ -192,8 +207,8 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 			manifest = emptyManifest();
 			return manifest;
 		}
-		requireSuccess(runJust(cwd, ["bootstrap"]), "just bootstrap");
-		const schemaOutput = requireSuccess(runJust(cwd, ["schema"]), "just schema");
+		requireSuccess(runJustRecipe(cwd, "bootstrap"), "just bootstrap");
+		const schemaOutput = requireSuccess(runJustRecipe(cwd, "schema"), "just schema");
 		const parsed = JSON.parse(schemaOutput) as Manifest;
 		manifest = parsed;
 		return parsed;
@@ -331,9 +346,10 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 			}
 			validateArgs(tool, args);
 
-			const result = runJust(
+			const result = runJustRecipe(
 				ctx.cwd,
-				[params.recipe, ...buildRecipeArguments(tool, args)],
+				params.recipe,
+				buildRecipeArguments(tool, args),
 			);
 			const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim() || "(no output)";
 			return {
@@ -359,7 +375,7 @@ export default function justConsumerExtension(pi: ExtensionAPI) {
 					"No Justfile found in this workspace, so just_escalate cannot add or refresh recipes yet.",
 				);
 			}
-			const result = runJust(ctx.cwd, ["escalate", params.prompt]);
+			const result = runJustRecipe(ctx.cwd, "escalate", [params.prompt]);
 			requireSuccess(result, "just escalate");
 			const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
 			const currentManifest = refreshManifest(ctx.cwd);
@@ -440,7 +456,7 @@ Consumer mode rules:
 - Treat just schema as the authoritative API surface.
 - If just_schema returns no recipes, explain that the workspace has no Justfile yet and do not invent tools.
 - Pass just_run arguments by schema parameter name, but remember the extension executes just recipe parameters positionally.
-- For example, for md5(file), call just_run with args like {"file": "/path/to/file"} and let the extension run \`just md5 /path/to/file\`.
+- For example, for md5(file), call just_run with args like {"file": "/path/to/file"} and let the extension run \`just --one md5 /path/to/file\`.
 - When keyed args skip an optional parameter that has a schema default, the extension fills that default automatically before executing the positional just recipe.
 - For the research recipe, \`rounds\` means how many new rounds to run in this invocation, not a retry count for round 1 and not a total-to-date target.
 - If the user asks for one research iteration or one more round, call research with \`{"rounds": "1"}\` and let the recipe append the next round automatically.

--- a/just_for_agents/__main__.py
+++ b/just_for_agents/__main__.py
@@ -33,7 +33,7 @@ from .mutations import (
     create_new_request,
 )
 from .projection import write_include
-from .request_store import RequestStore
+from .request_store import RequestStore, RequestValidationError
 from .review import ReviewError, render_dashboard_text, write_dashboard, write_request_review
 
 
@@ -60,7 +60,11 @@ def cmd_bootstrap(_args: argparse.Namespace) -> int:
 def cmd_queue(_args: argparse.Namespace) -> int:
     paths = ensure_managed_layout(_repo_root())
     store = RequestStore(paths)
-    requests = store.list_quarantined()
+    try:
+        requests = store.list_quarantined()
+    except RequestValidationError as exc:
+        print(f"queue failed: {exc}", file=sys.stderr)
+        return 1
     if not requests:
         print("(no quarantined requests)")
         return 0
@@ -75,7 +79,11 @@ def cmd_queue(_args: argparse.Namespace) -> int:
 def cmd_inspect(args: argparse.Namespace) -> int:
     paths = ensure_managed_layout(_repo_root())
     store = RequestStore(paths)
-    request = store.get(args.request_id)
+    try:
+        request = store.get(args.request_id)
+    except RequestValidationError as exc:
+        print(f"inspect failed: {exc}", file=sys.stderr)
+        return 1
     if request is None:
         print(f"unknown request: {args.request_id}", file=sys.stderr)
         return 1
@@ -107,7 +115,7 @@ def cmd_new(args: argparse.Namespace) -> int:
             author_label=args.author,
             review_notes=args.review_notes,
         )
-    except MutationError as exc:
+    except (MutationError, RequestValidationError) as exc:
         print(f"mutation failed: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(_request_payload(store, request.request_id, candidate, "candidate_path"), indent=2, sort_keys=True))
@@ -125,7 +133,7 @@ def cmd_edit(args: argparse.Namespace) -> int:
             author_label=args.author,
             review_notes=args.review_notes,
         )
-    except MutationError as exc:
+    except (MutationError, RequestValidationError) as exc:
         print(f"mutation failed: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(_request_payload(store, request.request_id, candidate, "candidate_path"), indent=2, sort_keys=True))
@@ -143,7 +151,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
             author_label=args.author,
             review_notes=args.review_notes,
         )
-    except MutationError as exc:
+    except (MutationError, RequestValidationError) as exc:
         print(f"mutation failed: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(_request_payload(store, request.request_id, tombstone, "tombstone_path"), indent=2, sort_keys=True))

--- a/just_for_agents/dry_run.py
+++ b/just_for_agents/dry_run.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from .managed_paths import ManagedPaths
-from .request_store import Request, RequestStore
+from .request_store import Request, RequestStore, RequestValidationError
 
 
 class DryRunError(RuntimeError):
@@ -89,6 +89,7 @@ def _write_session_justfile(paths: ManagedPaths, request: Request, target_dir: P
 def _run_just_dry_run(paths: ManagedPaths, session_justfile: Path, recipe_name: str) -> dict[str, Any]:
     command = [
         "just",
+        "--one",
         "--working-directory",
         str(paths.repo_root),
         "--justfile",
@@ -174,7 +175,10 @@ def run_request_dry_run(
 ) -> dict[str, Any]:
     """Run and persist a dry-run preview for one quarantined request."""
 
-    request = store.get(request_id)
+    try:
+        request = store.get(request_id)
+    except RequestValidationError as exc:
+        raise DryRunError(str(exc)) from exc
     if request is None:
         raise DryRunError(f"unknown request: {request_id}")
     if request.status != "quarantined":
@@ -194,17 +198,15 @@ def run_request_dry_run(
 
     if candidate.is_file():
         root_copy, session_justfile = _write_session_justfile(paths, request, dry_run_root)
-        recipe_results = [
-            _run_just_dry_run(paths, session_justfile, recipe_name)
-            for recipe_name in request.target_recipes
-        ]
+        recipe_name = request.target_recipes[0]
+        recipe_results = [_run_just_dry_run(paths, session_justfile, recipe_name)]
     elif tombstone.is_file():
+        recipe_name = request.target_recipes[0]
         recipe_results = [
             _skipped_recipe_result(
                 recipe_name,
                 "delete request has no candidate recipe body",
             )
-            for recipe_name in request.target_recipes
         ]
     else:
         raise DryRunError(

--- a/just_for_agents/history.py
+++ b/just_for_agents/history.py
@@ -19,7 +19,7 @@ from typing import Any
 from .drift import ManagedDriftError, ensure_clean_managed_surface
 from . import projection
 from .managed_paths import ManagedPaths
-from .request_store import Request, RequestStore
+from .request_store import Request, RequestStore, RequestValidationError
 
 
 class ApprovalError(RuntimeError):
@@ -125,7 +125,10 @@ def approve_request(
     Returns the decision-ledger entry that was written.
     """
 
-    request = store.get(request_id)
+    try:
+        request = store.get(request_id)
+    except RequestValidationError as exc:
+        raise ApprovalError(str(exc)) from exc
     if request is None:
         raise ApprovalError(f"unknown request: {request_id}")
     if request.status != "quarantined":

--- a/just_for_agents/request_store.py
+++ b/just_for_agents/request_store.py
@@ -23,6 +23,30 @@ VALID_SOURCES = frozenset(
 VALID_STATUSES = frozenset({"quarantined", "approved", "rejected", "superseded"})
 
 
+class RequestValidationError(ValueError):
+    """Raised when a request payload violates the managed single-recipe contract."""
+
+
+def _normalize_target_recipes(target_recipes: Iterable[str]) -> list[str]:
+    if isinstance(target_recipes, str):
+        raise RequestValidationError("target_recipes must be a list of recipe names")
+
+    recipes = [recipe.strip() for recipe in target_recipes]
+    if len(recipes) != 1:
+        raise RequestValidationError(
+            "managed requests must target exactly one recipe"
+        )
+
+    recipe_name = recipes[0]
+    if not recipe_name:
+        raise RequestValidationError("recipe name cannot be empty")
+    if any(char.isspace() for char in recipe_name):
+        raise RequestValidationError(
+            f"recipe name must be one token, got {recipe_name!r}"
+        )
+    return [recipe_name]
+
+
 @dataclass
 class Request:
     """A single change request."""
@@ -43,7 +67,38 @@ class Request:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Request":
-        return cls(**data)
+        try:
+            request_id = data["request_id"]
+            source = data["source"]
+            status = data["status"]
+            created_at = data["created_at"]
+            updated_at = data["updated_at"]
+        except KeyError as exc:
+            raise RequestValidationError(
+                f"request payload is missing required field {exc.args[0]!r}"
+            ) from exc
+
+        if source not in VALID_SOURCES:
+            raise RequestValidationError(
+                f"unknown request source: {source!r} (expected one of {sorted(VALID_SOURCES)})"
+            )
+        if status not in VALID_STATUSES:
+            raise RequestValidationError(
+                f"unknown request status: {status!r} (expected one of {sorted(VALID_STATUSES)})"
+            )
+
+        return cls(
+            request_id=request_id,
+            source=source,
+            status=status,
+            created_at=created_at,
+            updated_at=updated_at,
+            target_recipes=_normalize_target_recipes(data.get("target_recipes", [])),
+            author_label=data.get("author_label", ""),
+            review_notes=data.get("review_notes", ""),
+            risk_flags=list(data.get("risk_flags", [])),
+            dry_run_summary=data.get("dry_run_summary", ""),
+        )
 
 
 class RequestStore:
@@ -65,13 +120,14 @@ class RequestStore:
     def save(self, request: Request) -> Request:
         """Persist a request object back to disk."""
 
+        validated = Request.from_dict(request.to_dict())
         directory = self.request_dir(request.request_id)
         directory.mkdir(parents=True, exist_ok=True)
         self.request_file(request.request_id).write_text(
-            json.dumps(request.to_dict(), indent=2, sort_keys=True) + "\n",
+            json.dumps(validated.to_dict(), indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-        return request
+        return validated
 
     def create(
         self,
@@ -96,7 +152,7 @@ class RequestStore:
             status="quarantined",
             created_at=moment.isoformat(),
             updated_at=moment.isoformat(),
-            target_recipes=list(target_recipes),
+            target_recipes=_normalize_target_recipes(target_recipes),
             author_label=author_label,
             review_notes=review_notes,
             risk_flags=list(risk_flags or []),

--- a/just_for_agents/review.py
+++ b/just_for_agents/review.py
@@ -13,7 +13,7 @@ from typing import Any
 from .dry_run import load_dry_run_result
 from .drift import ManagedSurfaceStatus, managed_surface_status
 from .managed_paths import ManagedPaths
-from .request_store import RequestStore
+from .request_store import Request, RequestStore, RequestValidationError
 
 
 class ReviewError(RuntimeError):
@@ -60,10 +60,24 @@ def _latest_approval_by_recipe(paths: ManagedPaths) -> dict[str, dict[str, Any]]
 
 def _pending_requests_by_recipe(store: RequestStore) -> dict[str, list[str]]:
     pending: dict[str, list[str]] = {}
-    for request in store.list_quarantined():
+    for request in _list_quarantined(store):
         for recipe_name in request.target_recipes:
             pending.setdefault(recipe_name, []).append(request.request_id)
     return pending
+
+
+def _get_request(store: RequestStore, request_id: str) -> Request | None:
+    try:
+        return store.get(request_id)
+    except RequestValidationError as exc:
+        raise ReviewError(str(exc)) from exc
+
+
+def _list_quarantined(store: RequestStore) -> list[Request]:
+    try:
+        return store.list_quarantined()
+    except RequestValidationError as exc:
+        raise ReviewError(str(exc)) from exc
 
 
 def _dry_run_state(paths: ManagedPaths, request_id: str, summary: str) -> str:
@@ -158,7 +172,7 @@ def write_request_review(
 ) -> dict[str, Any]:
     """Render and persist one request's HTML review page."""
 
-    request = store.get(request_id)
+    request = _get_request(store, request_id)
     if request is None:
         raise ReviewError(f"unknown request: {request_id}")
     surface_status = managed_surface_status(paths)
@@ -287,7 +301,7 @@ def render_dashboard_text(paths: ManagedPaths, store: RequestStore) -> str:
             _dry_run_state(paths, request.request_id, request.dry_run_summary),
             request.dry_run_summary or "-",
         )
-        for request in store.list_quarantined()
+        for request in _list_quarantined(store)
     ]
     approvals = _latest_approval_by_recipe(paths)
     pending_by_recipe = _pending_requests_by_recipe(store)
@@ -352,7 +366,7 @@ def write_dashboard(
             _dry_run_state(paths, request.request_id, request.dry_run_summary),
             request.dry_run_summary or "-",
         )
-        for request in store.list_quarantined()
+        for request in _list_quarantined(store)
     ]
     approvals = _latest_approval_by_recipe(paths)
     pending_by_recipe = _pending_requests_by_recipe(store)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,9 +1,16 @@
 import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from just_for_agents.dry_run import load_dry_run_result, run_request_dry_run
+from just_for_agents.dry_run import (
+    _run_just_dry_run,
+    DryRunError,
+    load_dry_run_result,
+    run_request_dry_run,
+)
 from just_for_agents.managed_paths import ensure_managed_layout
 from just_for_agents.request_store import RequestStore
 
@@ -73,6 +80,59 @@ class RunRequestDryRunTests(unittest.TestCase):
             self.assertEqual(payload["status"], "skipped")
             self.assertIn("delete request has no candidate recipe body", payload["summary"])
             self.assertEqual(payload["recipe_results"][0]["status"], "skipped")
+
+    def test_rejects_multi_target_request_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            request_id = "req-20260501-001"
+            request_dir = paths.quarantine_requests_dir / request_id
+            request_dir.mkdir(parents=True, exist_ok=True)
+            (request_dir / "request.json").write_text(
+                json.dumps(
+                    {
+                        "request_id": request_id,
+                        "source": "manual-add",
+                        "status": "quarantined",
+                        "created_at": "2026-05-01T12:00:00+00:00",
+                        "updated_at": "2026-05-01T12:00:00+00:00",
+                        "target_recipes": ["hello", "world"],
+                        "author_label": "",
+                        "review_notes": "",
+                        "risk_flags": [],
+                        "dry_run_summary": "",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (request_dir / "candidate.just").write_text("hello:\n    echo hi\n", encoding="utf-8")
+
+            with self.assertRaises(DryRunError) as ctx:
+                run_request_dry_run(paths, store, request_id)
+
+            self.assertIn("exactly one recipe", str(ctx.exception))
+
+    def test_uses_just_one_for_direct_dry_run_execution(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, _ = _setup_repo(tmp)
+            session_justfile = Path(tmp) / "session.just"
+            session_justfile.write_text('import "root.just"\n', encoding="utf-8")
+            with patch(
+                "just_for_agents.dry_run.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["just"],
+                    returncode=0,
+                    stdout="preview\n",
+                    stderr="",
+                ),
+            ) as mock_run:
+                payload = _run_just_dry_run(paths, session_justfile, "hello")
+
+            command = mock_run.call_args.args[0]
+            self.assertEqual(command[:2], ["just", "--one"])
+            self.assertIn("--dry-run", command)
+            self.assertEqual(command[-1], "hello")
+            self.assertIn("just --one", payload["command"])
 
 
 if __name__ == "__main__":

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -175,6 +175,37 @@ class ApproveRequestTests(unittest.TestCase):
             with self.assertRaises(ApprovalError):
                 approve_request(paths, store, request.request_id)
 
+    def test_rejects_multi_target_request_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup(tmp)
+            request_id = "req-20260501-001"
+            request_dir = paths.quarantine_requests_dir / request_id
+            request_dir.mkdir(parents=True, exist_ok=True)
+            (request_dir / "request.json").write_text(
+                json.dumps(
+                    {
+                        "request_id": request_id,
+                        "source": "manual-add",
+                        "status": "quarantined",
+                        "created_at": "2026-05-01T12:00:00+00:00",
+                        "updated_at": "2026-05-01T12:00:00+00:00",
+                        "target_recipes": ["hello", "world"],
+                        "author_label": "",
+                        "review_notes": "",
+                        "risk_flags": [],
+                        "dry_run_summary": "",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (request_dir / "candidate.just").write_text("@hello:\n    echo hi\n", encoding="utf-8")
+
+            with self.assertRaises(ApprovalError) as ctx:
+                approve_request(paths, store, request_id)
+
+            self.assertIn("exactly one recipe", str(ctx.exception))
+
     def test_refuses_approval_when_governed_surface_has_drift(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             paths, store = _setup(tmp)

--- a/tests/test_request_store.py
+++ b/tests/test_request_store.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from just_for_agents.managed_paths import ensure_managed_layout
-from just_for_agents.request_store import RequestStore
+from just_for_agents.request_store import RequestStore, RequestValidationError
 
 
 def _store(tmp: str) -> RequestStore:
@@ -78,6 +78,38 @@ class RequestStoreTests(unittest.TestCase):
             store = _store(tmp)
             with self.assertRaises(ValueError):
                 store.create(source="bogus", target_recipes=["x"])
+
+    def test_multi_target_requests_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = _store(tmp)
+            with self.assertRaises(RequestValidationError):
+                store.create(source="manual-add", target_recipes=["alpha", "beta"])
+
+    def test_get_rejects_invalid_multi_target_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = _store(tmp)
+            request_dir = store.request_dir("req-20260501-001")
+            request_dir.mkdir(parents=True, exist_ok=True)
+            store.request_file("req-20260501-001").write_text(
+                json.dumps(
+                    {
+                        "request_id": "req-20260501-001",
+                        "source": "manual-add",
+                        "status": "quarantined",
+                        "created_at": "2026-05-01T12:00:00+00:00",
+                        "updated_at": "2026-05-01T12:00:00+00:00",
+                        "target_recipes": ["alpha", "beta"],
+                        "author_label": "",
+                        "review_notes": "",
+                        "risk_flags": [],
+                        "dry_run_summary": "",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(RequestValidationError):
+                store.get("req-20260501-001")
 
 
 if __name__ == "__main__":

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -8,7 +8,12 @@ from just_for_agents.history import append_decision, commit_approval, ensure_man
 from just_for_agents.managed_paths import ensure_managed_layout
 from just_for_agents.projection import write_include
 from just_for_agents.request_store import RequestStore
-from just_for_agents.review import render_dashboard_text, write_dashboard, write_request_review
+from just_for_agents.review import (
+    ReviewError,
+    render_dashboard_text,
+    write_dashboard,
+    write_request_review,
+)
 
 
 def _setup_repo(tmp: str):
@@ -42,6 +47,30 @@ def _seed_approved_recipe(
         },
     )
     commit_approval(paths, request_id=request_id, action="recipe")
+
+
+def _write_invalid_multi_target_request(paths, request_id: str) -> Path:
+    request_dir = paths.quarantine_requests_dir / request_id
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "request.json").write_text(
+        json.dumps(
+            {
+                "request_id": request_id,
+                "source": "manual-add",
+                "status": "quarantined",
+                "created_at": "2026-05-01T12:00:00+00:00",
+                "updated_at": "2026-05-01T12:00:00+00:00",
+                "target_recipes": ["hello", "world"],
+                "author_label": "",
+                "review_notes": "",
+                "risk_flags": [],
+                "dry_run_summary": "",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return request_dir
 
 
 class RequestReviewTests(unittest.TestCase):
@@ -96,6 +125,20 @@ class RequestReviewTests(unittest.TestCase):
             self.assertIn("drifted", html)
             self.assertIn("approved/recipes/hello.just", html)
 
+    def test_write_request_review_rejects_multi_target_request_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            request_id = "req-20260501-001"
+            request_dir = _write_invalid_multi_target_request(paths, request_id)
+            (request_dir / "candidate.just").write_text(
+                "hello:\n    echo candidate\n", encoding="utf-8"
+            )
+
+            with self.assertRaises(ReviewError) as ctx:
+                write_request_review(paths, store, request_id)
+
+            self.assertIn("exactly one recipe", str(ctx.exception))
+
 
 class DashboardTests(unittest.TestCase):
     def test_dashboard_lists_queue_library_and_settings(self) -> None:
@@ -143,6 +186,16 @@ class DashboardTests(unittest.TestCase):
             self.assertIn("approved/includes/managed.just", text)
             self.assertIn("drifted", html)
             self.assertIn("approved/includes/managed.just", html)
+
+    def test_dashboard_rejects_multi_target_request_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, store = _setup_repo(tmp)
+            _write_invalid_multi_target_request(paths, "req-20260501-001")
+
+            with self.assertRaises(ReviewError) as ctx:
+                render_dashboard_text(paths, store)
+
+            self.assertIn("exactly one recipe", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce single-recipe validation across managed request payloads and managed review paths
- guard direct agent-facing just execution with `just --one` in dry-run, research bootstrap, and the Pi consumer wrapper
- extend regressions for malformed multi-target payloads across review and dashboard flows

Closes #156